### PR TITLE
feat: 전반적인 설정 파일 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,14 @@ dependencies {
 
     // Aop
     implementation 'org.springframework.boot:spring-boot-starter-aop'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.9'
+
+    //Querydsl
+    implementation 'io.github.openfeign.querydsl:querydsl-core:6.11'
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa:6.11'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.11:jpa'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/uhdyl/backend/global/base/BaseEntity.java
+++ b/src/main/java/com/uhdyl/backend/global/base/BaseEntity.java
@@ -1,0 +1,33 @@
+package com.uhdyl.backend.global.base;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+import static lombok.AccessLevel.PROTECTED;
+
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+@MappedSuperclass // 실제 테이블을 가지지 않고, 상속하여 필드를 공유할 수 있게 함.
+@EntityListeners(AuditingEntityListener.class) // 이 엔터티 클래스의 상태 변화를 감지
+public abstract class BaseEntity {
+
+    @CreatedDate
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
+}

--- a/src/main/java/com/uhdyl/backend/global/config/querydsl/QueryDslConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/querydsl/QueryDslConfig.java
@@ -1,0 +1,20 @@
+package com.uhdyl.backend.global.config.querydsl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    @Bean
+    public JPAQueryFactory queryFactory(){
+        return new JPAQueryFactory(em);
+    }
+}
+

--- a/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerApiFailedResponse.java
+++ b/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerApiFailedResponse.java
@@ -1,0 +1,31 @@
+package com.uhdyl.backend.global.config.swagger;
+
+
+import com.uhdyl.backend.global.exception.ExceptionType;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 이 애너테이션은 API 호출이 실패했을 때의 응답 HTTP 상태 코드와 응답 본문에 대한
+ * 스키마를 명시할 수 있습니다.
+ *
+ * @see com.uhdyl.backend.global.config.swagger.SwaggerApiResponses
+ * @see ExceptionType
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SwaggerApiFailedResponse {
+    /**
+     * {@link ExceptionType}에 정의된 예외 타입을 지정합니다.
+     */
+    ExceptionType value();
+
+    /**
+     * Swagger UI에 표시할 실패 응답 설명을 기재합니다.
+     * <p>지정하지 않으면 {@link ExceptionType}의 기본 메시지가 사용됩니다.</p>
+     */
+    String description() default "";
+}

--- a/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerApiFailedResponseHandler.java
+++ b/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerApiFailedResponseHandler.java
@@ -1,0 +1,114 @@
+package com.uhdyl.backend.global.config.swagger;
+
+
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.FailedResponseBody;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import lombok.Builder;
+import lombok.Getter;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@Component
+public class SwaggerApiFailedResponseHandler {
+    public void handle(Operation operation, HandlerMethod handlerMethod) {
+        // 스프링 빈 컨트롤러 메서드에 적용된 SwaggerApiResponses 애너테이션을 불러옴
+        SwaggerApiResponses apiResponses = handlerMethod.getMethodAnnotation(SwaggerApiResponses.class);
+        if (apiResponses == null) {
+            return;
+        }
+
+        ApiResponses responses = operation.getResponses();
+
+        List<SwaggerApiFailedResponse> apiFailedResponses = Arrays.asList(apiResponses.errors());
+
+        // SwaggerApiFailedResponse를 ExampleHolder 객체로 만들어 HTTP 응답 상태 코드별로 저장
+        Map<Integer, List<ExampleHolder>> exampleHoldersGroupedByResponseCode = apiFailedResponses.stream()
+                .map(this::createExampleHolder)
+                .collect(Collectors.groupingBy(ExampleHolder::getResponseCode));
+
+        addExamplesToResponses(responses, exampleHoldersGroupedByResponseCode);
+    }
+
+    private ExampleHolder createExampleHolder(SwaggerApiFailedResponse apiFailedResponse) {
+        ExceptionType exceptionType = apiFailedResponse.value();
+        String description = apiFailedResponse.description().isBlank() ? exceptionType.getMessage() : apiFailedResponse.description();
+
+        return ExampleHolder.builder()
+                .responseCode(exceptionType.getStatus().value())
+                .exceptionName(exceptionType.name())
+                .exceptionCode(exceptionType.getCode())
+                .description(description)
+                .holder(createSwaggerExample(exceptionType, description))
+                .build();
+    }
+
+    private Example createSwaggerExample(ExceptionType exceptionType, String description) {
+        // 공통 응답 스키마 구성
+        FailedResponseBody failedResponseBody = new FailedResponseBody(exceptionType.getCode(), exceptionType.getMessage());
+        ExampleFailedResponseBody failedResponseBodyExample = new ExampleFailedResponseBody("false", failedResponseBody);
+
+        Example example = new Example();
+        example.setValue(failedResponseBodyExample);
+        example.setDescription(description);
+
+        return example;
+    }
+
+    private void addExamplesToResponses(
+            ApiResponses responses,
+            Map<Integer, List<ExampleHolder>> exampleHoldersGroupedByResponseCode
+    ) {
+        // 각 HTTP 응답 상태 코드별로 탐색
+        exampleHoldersGroupedByResponseCode.forEach((status, exampleHolders) -> {
+            Content content = new Content();
+            MediaType mediaType = new MediaType();
+            ApiResponse apiResponse = new ApiResponse();
+
+            // 각 상태 코드별 예제 생성
+            exampleHolders.forEach(
+                    exampleHolder -> mediaType.addExamples(exampleHolder.getExceptionName(), exampleHolder.getHolder())
+            );
+            
+            // 응답 객체 등록
+            content.addMediaType("application/json", mediaType);
+            apiResponse.setContent(content);
+            
+            responses.addApiResponse(String.valueOf(status), apiResponse);
+        });
+    }
+
+    @Getter
+    @Builder
+    public static class ExampleHolder {
+        private final int responseCode;
+        private final String exceptionName;
+        private final String exceptionCode;
+        private final String description;
+        private final Example holder;
+    }
+
+    @Getter
+    public static class ExampleFailedResponseBody {
+        private  final String success;
+        private  final String code;
+        private  final String message;
+
+        public ExampleFailedResponseBody(String success , FailedResponseBody failedResponseBody) {
+            this.success = success;
+            this.code = failedResponseBody.getCode();
+            this.message = failedResponseBody.getMsg();
+        }
+
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerApiResponses.java
+++ b/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerApiResponses.java
@@ -1,0 +1,20 @@
+package com.uhdyl.backend.global.config.swagger;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 이 애너테이션은 API 엔드 포인트에서의 성공 및 오류 응답에 대한 설명을 정의합니다.
+ *
+ * @see com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse
+ * @see com.uhdyl.backend.global.config.swagger.SwaggerApiFailedResponse
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SwaggerApiResponses {
+    SwaggerApiSuccessResponse success() default @SwaggerApiSuccessResponse;
+
+    SwaggerApiFailedResponse[] errors() default { };
+}

--- a/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerApiSuccessResponse.java
+++ b/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerApiSuccessResponse.java
@@ -1,0 +1,41 @@
+package com.uhdyl.backend.global.config.swagger;
+
+import org.springframework.http.HttpStatus;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * 이 애너테이션은 API 호출이 정상적으로 완료되었을 때의 응답 HTTP 상태 코드와 응답 본문에 대한
+ * 스키마를 명시할 수 있습니다.
+ *
+ * @see com.uhdyl.backend.global.config.swagger.SwaggerApiResponses
+ * @see HttpStatus
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface SwaggerApiSuccessResponse {
+    /**
+     * 반환할 HTTP 상태 코드를 지정합니다.
+     */
+    HttpStatus status() default HttpStatus.OK;
+
+    /**
+     * 단일 객체로 반환할 DTO 클래스 타입을 지정합니다.
+     * <p><code>responsePage</code>와 함께 사용할 수 없습니다.</p>
+     */
+    Class<?> response() default Void.class;
+
+    /**
+     * 페이지네이션된 리스트 형태로 반환할 DTO 클래스 타입을 지정합니다.
+     * <p><code>response</code>와 함께 사용할 수 없습니다.</p>
+     */
+    Class<?> responsePage() default Void.class;
+
+    /**
+     * Swagger UI에 표시할 응답 설명을 기재합니다.
+     */
+    String description() default "";
+}

--- a/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerApiSuccessResponseHandler.java
+++ b/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerApiSuccessResponseHandler.java
@@ -1,0 +1,86 @@
+package com.uhdyl.backend.global.config.swagger;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.media.*;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+@Component
+@RequiredArgsConstructor
+public class SwaggerApiSuccessResponseHandler {
+    public void handle(Operation operation, HandlerMethod handlerMethod) {
+        // 스프링 빈 컨트롤러 메서드에 적용된 SwaggerApiResponses 애너테이션을 불러옴
+        SwaggerApiResponses apiResponses = handlerMethod.getMethodAnnotation(SwaggerApiResponses.class);
+        if (apiResponses == null) {
+            return;
+        }
+        
+        // 내부의 SwaggerApiSuccessResponse 애너테이션을 불러옴
+        SwaggerApiSuccessResponse apiSuccessResponse = apiResponses.success();
+        if (apiSuccessResponse == null) {
+            return;
+        }
+
+        ApiResponses responses = operation.getResponses();
+        
+        // 기본 응답 및 200 HTTP 응답 상태 코드 삭제
+        String responseCode = String.valueOf(apiSuccessResponse.status().value());
+        responses.remove("default");
+        responses.remove(responseCode);
+
+        // 공통 응답 스키마 구성
+        Schema<?> dataSchema = resolveDataSchema(apiSuccessResponse);
+        Schema<?> responseSchema = new Schema<>()
+                .addProperty("success", new Schema<>().type("string").example("true"))
+                .addProperty("data", dataSchema);
+
+        // 응답 객체 생성 및 등록
+        ApiResponse apiResponse = new ApiResponse()
+                .description(apiSuccessResponse.description())
+                .content(new Content()
+                        .addMediaType("application/json", new MediaType().schema(responseSchema))
+                );
+
+        responses.addApiResponse(responseCode, apiResponse);
+    }
+
+    private Schema<?> resolveDataSchema(SwaggerApiSuccessResponse apiSuccessResponse) {
+        // SwaggerApiSuccessResponse의 responsePage 속성이 등록되었으면 GlobalPageResponse와 함께 응답을 출력하도록 스키마 구성
+        if (apiSuccessResponse.responsePage() != Void.class) {
+            return buildPageSchema(apiSuccessResponse.responsePage());
+        }
+
+        // SwaggerApiSuccessResponse의 response 속성이 등록되었으면 해당 객체의 응답을 출력하도록 스키마 구성
+        if (apiSuccessResponse.response() != Void.class) {
+            Class<?> responseClass = apiSuccessResponse.response();
+
+            // 배열로 속성 값이 등록되었으면 리스트 형식으로 응답을 출력하도록 스키마 구성
+            if (responseClass.isArray()) {
+                return new ArraySchema().items(refSchema(responseClass.getComponentType()));
+            }
+
+            return refSchema(responseClass);
+        }
+
+        // 속성이 등록되지 않았거나 Void.class라면 null을 출력하도록 스키마 구성
+        return new Schema<>().nullable(true).example(null);
+    }
+
+    private Schema<?> buildPageSchema(Class<?> responseClass) {
+        return new Schema<>()
+                .type("object")
+                .addProperty("pageNumber", new IntegerSchema().example(0).description("현재 페이지 번호 (0부터 시작)"))
+                .addProperty("pageSize", new IntegerSchema().example(12).description("페이지 당 항목 수"))
+                .addProperty("totalElements", new IntegerSchema().example(100).description("전체 항목 수"))
+                .addProperty("totalPages", new IntegerSchema().example(9).description("전체 페이지 수"))
+                .addProperty("pageSort", new StringSchema().example("companyName: ASC").description("정렬 정보"))
+                .addProperty("pageContents", new ArraySchema().description("페이지 내 컨텐츠 목록").items(refSchema(responseClass).description("요소는 호출 API에 따라 달라집니다")));
+    }
+
+    private Schema<?> refSchema(Class<?> responseClass) {
+        return new Schema<>().$ref("#/components/schemas/" + responseClass.getSimpleName());
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerConfig.java
@@ -1,0 +1,72 @@
+package com.uhdyl.backend.global.config.swagger;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.HandlerMethod;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(SwaggerProperties.class)
+public class SwaggerConfig {
+
+    private final SwaggerProperties swaggerProperties;
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("JWT");
+
+        return new OpenAPI()
+                .info(apiInfo())
+                .addServersItem(new Server()
+                        .url(swaggerProperties.getServerUrl())
+                        .description(swaggerProperties.getDescription()))
+                .addSecurityItem(securityRequirement)
+                .components(securitySchemes());
+    }
+
+    @Bean
+    public OperationCustomizer customize(
+            SwaggerApiSuccessResponseHandler apiSuccessResponseHandler,
+            SwaggerApiFailedResponseHandler apiFailedResponseHandler
+    ) {
+        return (Operation operation, HandlerMethod handlerMethod) -> {
+            apiSuccessResponseHandler.handle(operation, handlerMethod);
+            apiFailedResponseHandler.handle(operation, handlerMethod);
+
+            return operation;
+        };
+    }
+
+    private Info apiInfo() {
+        return new Info()
+                .title("UhDyL API 명세서")
+                .description("<p>이 문서는 UhDyL 백엔드 API의 사용 방법과 예시를 제공합니다.</p>" +
+                        "<p>API 사용 중 문제가 발생하거나 문의가 필요한 경우, 담당자에게 문의해 주세요.</p>" +
+                        "<p>입력 유효성 오류는 명시돼 있지 않으며 <code>4XX</code> 상태 코드를 반환합니다." +
+                        "<code>5XX</code> 상태 코드의 경우 정의되지 않은 서버 오류이므로 담당자에게 문의해 주세요.</p>")
+                .version("1.0.0");
+    }
+
+    private Components securitySchemes() {
+        final SecurityScheme accessTokenSecurityScheme = new SecurityScheme()
+                .name("JWT")
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("Bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name("Authorization");
+
+        return new Components()
+                .addSecuritySchemes("JWT", accessTokenSecurityScheme);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerProperties.java
+++ b/src/main/java/com/uhdyl/backend/global/config/swagger/SwaggerProperties.java
@@ -1,0 +1,13 @@
+package com.uhdyl.backend.global.config.swagger;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "babzip.swagger")
+public class SwaggerProperties {
+    private String serverUrl;
+    private String description;
+}

--- a/src/main/java/com/uhdyl/backend/global/exception/BusinessException.java
+++ b/src/main/java/com/uhdyl/backend/global/exception/BusinessException.java
@@ -1,0 +1,14 @@
+package com.uhdyl.backend.global.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException{
+
+    private final ExceptionType exceptionType;
+
+    public BusinessException(ExceptionType exceptionType){
+        super(exceptionType.getMessage());
+        this.exceptionType=exceptionType;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
+++ b/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
@@ -1,0 +1,36 @@
+package com.uhdyl.backend.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.*;
+
+@Getter
+@AllArgsConstructor
+public enum ExceptionType {
+
+    // Common
+    UNEXPECTED_SERVER_ERROR(INTERNAL_SERVER_ERROR,"C001","예상치 못한 에러 발생"),
+    BINDING_ERROR(BAD_REQUEST,"C002","바인딩시 에러 발생"),
+    ESSENTIAL_FIELD_MISSING_ERROR(NO_CONTENT , "C003","필수적인 필드 부재"),
+
+    // Security
+    ILLEGAL_REGISTRATION_ID(NOT_ACCEPTABLE, "S001", "잘못된 registration id 입니다"),
+    NEED_AUTHORIZED(UNAUTHORIZED, "S002", "인증이 필요합니다."),
+    ACCESS_DENIED(FORBIDDEN, "S003", "권한이 없습니다."),
+    JWT_EXPIRED(UNAUTHORIZED, "S004", "JWT 토큰이 만료되었습니다."),
+    JWT_INVALID(UNAUTHORIZED, "S005", "JWT 토큰이 올바르지 않습니다."),
+    JWT_NOT_EXIST(UNAUTHORIZED, "S006", "JWT 토큰이 존재하지 않습니다."),
+
+    // Token
+    REFRESH_TOKEN_NOT_EXIST(NOT_FOUND, "T001", "리프래시 토큰이 존재하지 않습니다"),
+    TOKEN_NOT_MATCHED(UNAUTHORIZED, "T002","일치하지 않는 토큰입니다"),
+
+    // User
+    USER_NOT_FOUND(NOT_FOUND, "U001","사용자가 존재하지 않습니다");
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/uhdyl/backend/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/uhdyl/backend/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,43 @@
+package com.uhdyl.backend.global.exception;
+
+import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.global.response.ResponseUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RequiredArgsConstructor
+@Slf4j
+@RestControllerAdvice(annotations = {RestController.class}, basePackages = {"com.uhdyl.backend"})
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<ResponseBody<Void>> businessException(BusinessException e, HttpServletRequest request) {
+        ExceptionType exceptionType = e.getExceptionType();
+        log.error("🔥 [{} {}] 요청 중 예외 발생: {}", request.getMethod(), request.getRequestURI(), e.getMessage(), e);
+
+        return ResponseEntity.status(exceptionType.getStatus())
+                .body(ResponseUtil.createFailureResponse(exceptionType));
+
+    }
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<ResponseBody<Void>> methodArgumentNotValidException(MethodArgumentNotValidException e){
+        String customMessage=e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
+        return ResponseEntity
+                .status(ExceptionType.BINDING_ERROR.getStatus())
+                .body(ResponseUtil.createFailureResponse(ExceptionType.BINDING_ERROR, customMessage));
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ResponseBody<Void>> exception(Exception e){
+        return ResponseEntity
+                .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ResponseUtil.createFailureResponse(ExceptionType.UNEXPECTED_SERVER_ERROR));
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/response/FailedResponseBody.java
+++ b/src/main/java/com/uhdyl/backend/global/response/FailedResponseBody.java
@@ -1,0 +1,16 @@
+package com.uhdyl.backend.global.response;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.Getter;
+@Getter
+@JsonTypeName("false")
+public final class FailedResponseBody extends ResponseBody<Void> {
+
+    private final String msg;
+
+    public FailedResponseBody(String code, String msg){
+        this.setCode(code);
+        this.msg=msg;
+    }
+
+}

--- a/src/main/java/com/uhdyl/backend/global/response/GlobalPageResponse.java
+++ b/src/main/java/com/uhdyl/backend/global/response/GlobalPageResponse.java
@@ -1,0 +1,49 @@
+package com.uhdyl.backend.global.response;
+
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class GlobalPageResponse<T> {
+
+    private final int pageNumber;
+
+    private final int pageSize;
+
+    private final long totalElements;
+
+    private final int totalPages;
+
+    private final String pageSort;
+
+    private final List<T> pageContents;
+
+    public GlobalPageResponse(
+            int pageNumber,
+            int pageSize,
+            long totalElements,
+            int totalPages,
+            String pageSort,
+            List<T> pageContents
+    ) {
+        this.pageNumber = pageNumber;
+        this.pageSize = pageSize;
+        this.totalElements = totalElements;
+        this.totalPages = totalPages;
+        this.pageSort = pageSort;
+        this.pageContents = pageContents;
+    }
+
+    public static <T> GlobalPageResponse<T> create(Page<T> pageDto) {
+        return new GlobalPageResponse<>(
+                pageDto.getNumber(),
+                pageDto.getSize(),
+                pageDto.getTotalElements(),
+                pageDto.getTotalPages(),
+                pageDto.getSort().toString(),
+                pageDto.getContent());
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/response/ResponseBody.java
+++ b/src/main/java/com/uhdyl/backend/global/response/ResponseBody.java
@@ -1,0 +1,23 @@
+package com.uhdyl.backend.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import lombok.Getter;
+import lombok.Setter;
+
+@Setter
+@Getter
+@JsonTypeInfo( // 다형성 처리, 어떤 하위 클래스로 역직렬화 할지
+        use=JsonTypeInfo.Id.NAME, // NAME을 사용하여 각 하위 클래스에 대해 이름을 지정
+        include = JsonTypeInfo.As.PROPERTY, // 타입 정보를 JSON 속성으로 포함시킨다.
+        property = "success")   // property이름 : success
+@JsonSubTypes({ // 어떤 응답을 사용할지 컴퓨터가 알아차리도록 도와주는 표시
+        @JsonSubTypes.Type(value= SuccessResponseBody.class,name="true"), // SuccessResponseBody: name을 true로 지정
+        @JsonSubTypes.Type(value= FailedResponseBody.class,name="false")  // name을 false로 지정
+})
+
+public sealed  abstract class ResponseBody<T> permits SuccessResponseBody, FailedResponseBody {
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String code;
+}

--- a/src/main/java/com/uhdyl/backend/global/response/ResponseUtil.java
+++ b/src/main/java/com/uhdyl/backend/global/response/ResponseUtil.java
@@ -1,0 +1,28 @@
+package com.uhdyl.backend.global.response;
+
+import com.uhdyl.backend.global.exception.ExceptionType;
+
+public class ResponseUtil {
+
+    public static ResponseBody<Void> createSuccessResponse() {
+        return new SuccessResponseBody<>();
+    }
+
+    public static <T> ResponseBody<T> createSuccessResponse(T data) {
+        return new SuccessResponseBody<>(data);
+    }
+
+    public static ResponseBody<Void> createFailureResponse(ExceptionType exceptionType) {
+        return new FailedResponseBody(
+                exceptionType.getCode(),
+                exceptionType.getMessage()
+        );
+    }
+
+    public static ResponseBody<Void> createFailureResponse(ExceptionType exceptionType, String customMessage) {
+        return new FailedResponseBody(
+                exceptionType.getCode(),
+                customMessage
+        );
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/response/SuccessResponseBody.java
+++ b/src/main/java/com/uhdyl/backend/global/response/SuccessResponseBody.java
@@ -1,0 +1,17 @@
+package com.uhdyl.backend.global.response;
+
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import lombok.Getter;
+
+@Getter
+@JsonTypeName("true") // 이 클래스가 직렬화될 때 어떤 이름을 가질지 명시적으로 지정, 명시성을 높이기 위해 재지정한 것임
+
+public final class SuccessResponseBody<T> extends ResponseBody<T> {  // 더 이상 다른 클래스에 의해 상속될 수 없다는 뜻, 불필요한 상속으로 인한 복잡성을 줄이고, 클래스의 무결성을 유지할 수 있다.
+    private final T data;  // 성공 응답이 생성된 후에는 그 응답의 데이터가 변경되지 않아야 하는 경우가 많다.
+    public SuccessResponseBody(){
+        data=null;
+    }
+    public SuccessResponseBody(T result){
+        this.data=result;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/scheduler/RefreshTokenDeleteScheduler.java
+++ b/src/main/java/com/uhdyl/backend/global/scheduler/RefreshTokenDeleteScheduler.java
@@ -1,0 +1,24 @@
+package com.uhdyl.backend.global.scheduler;
+
+import com.uhdyl.backend.token.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+public class RefreshTokenDeleteScheduler {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void deleteExpiredToken() {
+        refreshTokenRepository.deleteAllRefreshToken(LocalDateTime.now());
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -5,6 +5,7 @@ spring:
     import:
       - security/application-database.yml
       - security/application-security.yml
+      - security/application-swagger.yml
 
   datasource:
     url: ${UhDyL.mysql.url}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -5,6 +5,7 @@ spring:
     import:
       - security/application-database.yml
       - security/application-security.yml
+      - security/application-swagger.yml
 
   datasource:
     url: ${UhDyL.mysql.url}


### PR DESCRIPTION
## What is this PR?🔍
- 프로젝트 진행을 위한 전반적인 설정 파일을 추가합니다.

## Changes💻
- 문서화를 위해 사용할 swagger 설정 코드를 추가했습니다.
- 검색 기능을 위해 QueryDSL 설정 코드를 추가했습니다.
- 모든 엔티티(도메인)에서 공통으로 사용할 `BaseEntity`를 추가했습니다. JPA Auditing을 사용해 엔티티의 생성일, 수정일, 삭제일을 관리합니다.
- 리프래시 토큰을 redis에 저장하지 않고 DB에 저장했기에 리프래시 토큰이 만료될 시 자동으로 DB에서 삭제하도록 스케줄러를 추가했습니다.
- 컨트롤러에서 발생하는 예외들을 일관되게 처리하기 위해 `GlobalExceptionHandler`를 추가했습니다.
- API 응답의 일관성을 위해 추상클래스 `ResponseBody`를 추가했습니다.
- 

## ScreenShot📷
