### PR TITLE
feat: Spring Security 설정과 OAuth2.0 로그인 구현 및 JWT 설정 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/UhDyLBackendApplication.java
+++ b/src/main/java/com/uhdyl/backend/UhDyLBackendApplication.java
@@ -1,9 +1,14 @@
 package com.uhdyl.backend;
 
+import com.uhdyl.backend.global.oauth.user.KakaoProperties;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
+@EnableConfigurationProperties(KakaoProperties.class)
 public class UhDyLBackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/com/uhdyl/backend/global/aop/AssignUserId.java
+++ b/src/main/java/com/uhdyl/backend/global/aop/AssignUserId.java
@@ -1,0 +1,12 @@
+package com.uhdyl.backend.global.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.METHOD)
+public @interface AssignUserId {
+    boolean required() default true;
+}

--- a/src/main/java/com/uhdyl/backend/global/aop/UserIdInjectionAspect.java
+++ b/src/main/java/com/uhdyl/backend/global/aop/UserIdInjectionAspect.java
@@ -1,0 +1,60 @@
+package com.uhdyl.backend.global.aop;
+
+import com.uhdyl.backend.global.jwt.JwtAuthentication;
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.security.authentication.AnonymousAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+
+import java.lang.reflect.Parameter;
+
+@Slf4j
+@Aspect
+@Component
+public class UserIdInjectionAspect {
+    @Pointcut("@annotation(com.uhdyl.backend.global.aop.AssignUserId) && (args(userId, ..) || args(.., userId))")
+    public void userIdAnnotatedMethod(Long userId) {
+    }
+
+    @Around(value = "userIdAnnotatedMethod(userId)", argNames = "joinPoint,userId")
+    public Object injectUserId(ProceedingJoinPoint joinPoint, Long userId) throws Throwable {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        log.info("UserId : {}", (Long) authentication.getPrincipal());
+
+        if (authentication instanceof JwtAuthentication) {
+            userId = (Long) authentication.getPrincipal();
+        } else if (authentication instanceof AnonymousAuthenticationToken) {
+            MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+            AssignUserId assignUserIdAnnotation = signature.getMethod().getAnnotation(AssignUserId.class);
+            if (assignUserIdAnnotation.required()) {
+                log.error("Null Authentication error {}", authentication.getClass());
+                throw new IllegalArgumentException("You must login to use this service.");
+            } else {
+                log.info("Anonymous Authentication, userId is null");
+                userId = null;
+            }
+        } else {
+            log.error("JwtAuthentication Type Casting Error {}", authentication.getClass());
+            throw new IllegalArgumentException("Only JWT-based authentication is supported for @AssignUserId annotation.");
+        }
+
+        Object[] args = joinPoint.getArgs();
+        MethodSignature signature = (MethodSignature) joinPoint.getSignature();
+        Parameter[] parameters = signature.getMethod().getParameters();
+
+        for (int i = 0; i < parameters.length; i++) {
+            if (parameters[i].getType() == Long.class && args[i] == null) {
+                args[i] = userId;
+                break;
+            }
+        }
+
+        return joinPoint.proceed(args);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/config/security/AuthenticationConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/security/AuthenticationConfig.java
@@ -1,0 +1,17 @@
+package com.uhdyl.backend.global.config.security;
+
+import com.uhdyl.backend.global.jwt.TokenProvider;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.ProviderManager;
+
+@Configuration
+public class AuthenticationConfig {
+    @Bean
+    public AuthenticationManager authenticationManager(
+            TokenProvider tokenProvider
+    ) {
+        return new ProviderManager(tokenProvider);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/config/security/CorsConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/security/CorsConfig.java
@@ -1,0 +1,25 @@
+package com.uhdyl.backend.global.config.security;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+    public static CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(List.of("http://localhost:8080", "http://localhost:5173"));
+        configuration.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE"));
+        configuration.setAllowedHeaders(List.of("*"));
+        configuration.setMaxAge(3600L);
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+
+        return source;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/config/security/JwtConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/security/JwtConfig.java
@@ -1,0 +1,22 @@
+package com.uhdyl.backend.global.config.security;
+
+import com.uhdyl.backend.global.jwt.JwtHandler;
+import com.uhdyl.backend.global.jwt.JwtProperties;
+import com.uhdyl.backend.token.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(JwtProperties.class)
+public class JwtConfig {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Bean
+    public JwtHandler jwtHandler(JwtProperties jwtProperties) {
+        return new JwtHandler(jwtProperties, refreshTokenRepository);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/config/security/PasswordEncoderConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/security/PasswordEncoderConfig.java
@@ -1,0 +1,15 @@
+package com.uhdyl.backend.global.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+
+    @Bean
+    // @Bean은 해당 메서드의 리턴되는 오브젝트를 IoC로 등록해줌
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/security/SecurityConfig.java
@@ -61,8 +61,8 @@ public class SecurityConfig {
     public RoleHierarchy roleHierarchy() {
         return RoleHierarchyImpl
                 .withDefaultRolePrefix()  // 기본 접두어 "ROLE_" 사용
-                .role("ADMIN")            // ROLE_ADMIN
-                .implies("USER")        // ROLE_USER
+                .role("FARMER")
+                .implies("USER")
                 .build();
     }
 

--- a/src/main/java/com/uhdyl/backend/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/security/SecurityConfig.java
@@ -1,0 +1,76 @@
+package com.uhdyl.backend.global.config.security;
+
+
+import com.uhdyl.backend.global.jwt.JwtAuthenticationFilter;
+import com.uhdyl.backend.global.oauth.handler.OAuth2AuthenticationSuccessHandler;
+import com.uhdyl.backend.global.oauth.resolver.CustomAuthorizationRequestResolver;
+import com.uhdyl.backend.global.oauth.service.CustomOAuth2UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.access.expression.method.DefaultMethodSecurityExpressionHandler;
+import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchy;
+import org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@EnableMethodSecurity
+@RequiredArgsConstructor
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
+    private final AuthenticationManager authenticationManager;
+    private final CustomAuthorizationRequestResolver customAuthorizationRequestResolver;
+
+    @Bean
+    public SecurityFilterChain filterChainPermitAll(HttpSecurity http) throws Exception {
+        return defaultSecurity(http)
+                // 일시적으로 모든 URL에 대해 권한 확인을 시행하지 않음
+                .authorizeHttpRequests(req ->
+                        req.anyRequest().permitAll())
+                .build();
+    }
+
+    public HttpSecurity defaultSecurity(HttpSecurity http) throws Exception {
+        return http
+                .csrf(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .formLogin(AbstractHttpConfigurer::disable)
+                .cors(cors -> cors.configurationSource(CorsConfig.corsConfigurationSource()))
+                .oauth2Login(oauth2 -> oauth2
+                        .authorizationEndpoint(auth ->
+                                auth.authorizationRequestResolver(customAuthorizationRequestResolver))
+                        .userInfoEndpoint(ui ->
+                                ui.userService(customOAuth2UserService))
+                        .successHandler(oAuth2AuthenticationSuccessHandler)
+                )
+                .addFilterAfter(new JwtAuthenticationFilter(authenticationManager),
+                        UsernamePasswordAuthenticationFilter.class);
+    }
+
+    @Bean
+    public RoleHierarchy roleHierarchy() {
+        return RoleHierarchyImpl
+                .withDefaultRolePrefix()  // 기본 접두어 "ROLE_" 사용
+                .role("ADMIN")            // ROLE_ADMIN
+                .implies("USER")        // ROLE_USER
+                .build();
+    }
+
+    @Bean
+    public MethodSecurityExpressionHandler expressionHandler(RoleHierarchy roleHierarchy) {
+        DefaultMethodSecurityExpressionHandler expressionHandler = new DefaultMethodSecurityExpressionHandler();
+        expressionHandler.setRoleHierarchy(roleHierarchy);
+        return expressionHandler;
+    }
+
+}

--- a/src/main/java/com/uhdyl/backend/global/config/web/WebClientConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/web/WebClientConfig.java
@@ -1,0 +1,20 @@
+package com.uhdyl.backend.global.config.web;
+
+import com.uhdyl.backend.global.oauth.user.KakaoProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+import org.springframework.web.reactive.function.client.WebClient;
+
+@Configuration
+public class WebClientConfig {
+
+    @Bean
+    public WebClient kakaoWebClient(KakaoProperties kakaoProperties) {
+        return WebClient.builder()
+                .baseUrl("https://dapi.kakao.com/v2/local")
+                .defaultHeader(HttpHeaders.AUTHORIZATION,
+                        "KakaoAK " + kakaoProperties.getClientId())
+                .build();
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/JwtAuthentication.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/JwtAuthentication.java
@@ -1,0 +1,57 @@
+package com.uhdyl.backend.global.jwt;
+
+import com.uhdyl.backend.user.domain.UserRole;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public record JwtAuthentication(
+        Long userId,
+        UserRole role
+) implements Authentication {
+
+    public JwtAuthentication(JwtUserClaim claims) {
+        this(
+                claims.userId(),
+                claims.role()
+        );
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singleton(new SimpleGrantedAuthority(this.role().name()));
+    }
+
+    @Override
+    public Object getCredentials() {
+        return null;
+    }
+
+    @Override
+    public Object getDetails() {
+        return null;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return userId;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return true;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,79 @@
+package com.uhdyl.backend.global.jwt;
+
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.uhdyl.backend.global.jwt.exception.JwtAuthenticationException;
+import com.uhdyl.backend.global.jwt.exception.JwtNotExistException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.web.util.matcher.RequestHeaderRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.Optional;
+
+import static com.uhdyl.backend.global.response.ResponseUtil.createFailureResponse;
+
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+    private final AuthenticationManager authenticationManager;
+    private final RequestMatcher requestMatcher = new RequestHeaderRequestMatcher(HttpHeaders.AUTHORIZATION);
+    private static final Logger log = LoggerFactory.getLogger(JwtAuthenticationFilter.class);
+
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String method = request.getMethod();
+        String uri = request.getRequestURI();
+
+        log.info("🔍 API 요청: {} {}", method, uri);
+
+        // Authorization 헤더가 있을 때만 필터를 거쳐감
+        // 인증이 필요없는 작업은 이 필터를 거치지 않음
+        if (!requestMatcher.matches(request)) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        try {
+            String tokenValue = resolveToken(request).orElseThrow(JwtNotExistException::new);
+            JwtAuthenticationToken token = new JwtAuthenticationToken(tokenValue); // 인증되지 않은 토큰
+            Authentication authentication = this.authenticationManager.authenticate(token); // TokenProvider에게 위임
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            filterChain.doFilter(request, response);
+        } catch (JwtAuthenticationException e) {
+            this.handleServiceException(response, e);
+        }
+    }
+
+    private Optional<String> resolveToken(HttpServletRequest request){
+        String bearerToken = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if(bearerToken != null && bearerToken.startsWith(BEARER_PREFIX)){
+            return Optional.of(bearerToken.substring(BEARER_PREFIX.length()));
+        }
+        return Optional.empty();
+    }
+
+    private void handleServiceException(HttpServletResponse response, JwtAuthenticationException e) throws IOException {
+        response.setStatus(e.getErrorCode().getStatus().value());
+        response.setContentType("application/json;charset=UTF-8");
+        ObjectMapper objectMapper = new ObjectMapper();
+        String errorResponse = objectMapper.writeValueAsString(createFailureResponse(e.getErrorCode()));
+        response.getWriter().write(errorResponse);
+        response.flushBuffer(); // 커밋
+        response.getWriter().close();
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/JwtAuthenticationToken.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/JwtAuthenticationToken.java
@@ -1,0 +1,48 @@
+package com.uhdyl.backend.global.jwt;
+
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+
+import java.util.Collection;
+import java.util.Collections;
+
+public record JwtAuthenticationToken(
+        String token
+) implements Authentication {
+
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public Object getCredentials() {
+        return token;
+    }
+
+    @Override
+    public Object getDetails() {
+        return token;
+    }
+
+    @Override
+    public Object getPrincipal() {
+        return null;
+    }
+
+    @Override
+    public boolean isAuthenticated() {
+        return false;
+    }
+
+    @Override
+    public void setAuthenticated(boolean isAuthenticated) throws IllegalArgumentException {
+
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/JwtHandler.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/JwtHandler.java
@@ -1,0 +1,101 @@
+package com.uhdyl.backend.global.jwt;
+
+
+import com.uhdyl.backend.token.entity.RefreshToken;
+import com.uhdyl.backend.token.entity.Token;
+import com.uhdyl.backend.token.repository.RefreshTokenRepository;
+import com.uhdyl.backend.user.domain.UserRole;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+
+public class JwtHandler {
+
+    private final JwtProperties jwtProperties;
+    private final SecretKey secretKey;
+    private final RefreshTokenRepository refreshTokenRepository;
+    public static final String USER_ID = "USER_ID";
+    public static final String USER_ROLE = "USER_ROLE";
+    private static final String KEY_ROLE = "role";
+    private static final long MILLI_SECOND = 1000L;
+
+    public JwtHandler(JwtProperties jwtProperties, RefreshTokenRepository refreshTokenRepository) {
+        this.jwtProperties = jwtProperties;
+        this.refreshTokenRepository = refreshTokenRepository;
+        secretKey = new SecretKeySpec(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
+    }
+
+    public Token createTokens(JwtUserClaim jwtUserClaim) {
+        Map<String, Object> tokenClaims = this.createClaims(jwtUserClaim);
+        Date now = new Date(System.currentTimeMillis());
+        long accessTokenExpireIn = jwtProperties.getAccessTokenExpireIn();
+
+        String accessToken = Jwts.builder()
+                .claims(tokenClaims)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + accessTokenExpireIn * MILLI_SECOND))
+                .signWith(secretKey)
+                .compact();
+
+        String refreshToken = UUID.randomUUID().toString();
+        long refreshTokenExpireIn = jwtProperties.getRefreshTokenExpireIn();
+        RefreshToken refreshTokenEntity = new RefreshToken(jwtUserClaim.userId(), refreshToken, refreshTokenExpireIn);
+        refreshTokenRepository.save(refreshTokenEntity);
+
+        return Token.builder()
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+
+    public Map<String, Object> createClaims(JwtUserClaim jwtUserClaim) {
+        return Map.of(
+                USER_ID, jwtUserClaim.userId(),
+                USER_ROLE, jwtUserClaim.role()
+        );
+    }
+
+
+    // 재발급을 위해 token이 만료되었더라도 claim을 반환하는 메서드
+    public Optional<JwtUserClaim> getClaims(String token) {
+        try {
+            Claims claims = Jwts.parser()
+                    .verifyWith(secretKey)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload();
+            return Optional.of(this.convert(claims));
+        } catch (ExpiredJwtException e) {
+            Claims claims = e.getClaims();
+            return Optional.of(this.convert(claims));
+        } catch (Exception e) {
+            return Optional.empty();
+        }
+    }
+
+    public JwtUserClaim convert(Claims claims) {
+        return new JwtUserClaim(
+                claims.get(USER_ID, Long.class),
+                UserRole.valueOf(claims.get(USER_ROLE, String.class))
+        );
+    }
+
+    // 필터에서 토큰의 상태를 검증하기 위한 메서드 exception은 사용하는 곳에서 처리
+    public JwtUserClaim parseToken(String token) {
+        Claims claims = Jwts.parser()
+                .verifyWith(secretKey)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+
+        return this.convert(claims);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/JwtHandler.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/JwtHandler.java
@@ -23,7 +23,7 @@ public class JwtHandler {
     private final SecretKey secretKey;
     private final RefreshTokenRepository refreshTokenRepository;
     public static final String USER_ID = "USER_ID";
-    public static final String USER_ROLE = "USER_ROLE";
+    public static final String USER_ROLE = "ROLE_USER";
     private static final String KEY_ROLE = "role";
     private static final long MILLI_SECOND = 1000L;
 

--- a/src/main/java/com/uhdyl/backend/global/jwt/JwtProperties.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/JwtProperties.java
@@ -1,0 +1,14 @@
+package com.uhdyl.backend.global.jwt;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "uhdyl.jwt")
+public class JwtProperties {
+    private String secretKey;
+    private int accessTokenExpireIn;
+    private int refreshTokenExpireIn;
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/JwtUserClaim.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/JwtUserClaim.java
@@ -1,0 +1,17 @@
+package com.uhdyl.backend.global.jwt;
+
+
+import com.uhdyl.backend.user.domain.User;
+import com.uhdyl.backend.user.domain.UserRole;
+
+public record  JwtUserClaim(
+        Long userId,
+        UserRole role
+) {
+    public static JwtUserClaim create(User user) {
+        return new JwtUserClaim(user.getId(), user.getRole());
+    }
+    public static JwtUserClaim create(Long userId, UserRole role) {
+        return new JwtUserClaim(userId, role);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/TokenProvider.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/TokenProvider.java
@@ -1,0 +1,61 @@
+package com.uhdyl.backend.global.jwt;
+
+
+import com.uhdyl.backend.global.jwt.exception.JwtAccessDeniedException;
+import com.uhdyl.backend.global.jwt.exception.JwtTokenExpiredException;
+import com.uhdyl.backend.global.jwt.exception.JwtTokenInvalidException;
+import com.uhdyl.backend.user.domain.UserRole;
+import com.uhdyl.backend.user.service.UserService;
+import io.jsonwebtoken.ExpiredJwtException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationProvider;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.stereotype.Component;
+
+
+@RequiredArgsConstructor
+@Component
+@Slf4j
+public class TokenProvider implements AuthenticationProvider {
+
+    private final JwtHandler jwtHandler;
+    private final UserService userService;
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        JwtAuthenticationToken jwtAuthenticationToken = (JwtAuthenticationToken) authentication;
+        String tokenValue = jwtAuthenticationToken.token();
+        if (tokenValue == null) {
+            log.info("null이에요");
+            return null;
+        }
+        log.info("널이 아니에여ㅛ");
+        try {
+            JwtUserClaim claims = jwtHandler.parseToken(tokenValue);
+            this.validateFarmerRole(claims);
+            return new JwtAuthentication(claims);
+        } catch (ExpiredJwtException e) {
+            throw new JwtTokenExpiredException(e);
+        } catch (JwtAccessDeniedException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new JwtTokenInvalidException(e);
+        }
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return JwtAuthenticationToken.class.isAssignableFrom(authentication);
+    }
+
+    private void validateFarmerRole(JwtUserClaim claims) {
+        Long userId = claims.userId();
+
+        // 토큰의 권한은 FARMER지만 DB에 저장된 권한이 FARMER가 아닌 경우 예외 반환
+        if (UserRole.FARMER.equals(claims.role()) && !userService.isFarmer(userId)) {
+            throw new JwtAccessDeniedException();
+        }
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/exception/JwtAccessDeniedException.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/exception/JwtAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.global.jwt.exception;
+
+
+import com.uhdyl.backend.global.exception.ExceptionType;
+
+public class JwtAccessDeniedException extends JwtAuthenticationException {
+    public JwtAccessDeniedException() {
+        super(ExceptionType.ACCESS_DENIED);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/exception/JwtAuthenticationException.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/exception/JwtAuthenticationException.java
@@ -1,0 +1,20 @@
+package com.uhdyl.backend.global.jwt.exception;
+
+import com.uhdyl.backend.global.exception.ExceptionType;
+import lombok.Getter;
+import org.springframework.security.core.AuthenticationException;
+
+@Getter
+public class JwtAuthenticationException extends AuthenticationException {
+    private ExceptionType errorCode;
+
+    public JwtAuthenticationException(ExceptionType errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public JwtAuthenticationException(Throwable cause, ExceptionType errorCode) {
+        super(errorCode.getMessage(), cause);
+        this.errorCode = errorCode;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/exception/JwtNotExistException.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/exception/JwtNotExistException.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.global.jwt.exception;
+
+
+import com.uhdyl.backend.global.exception.ExceptionType;
+
+public class JwtNotExistException extends JwtAuthenticationException {
+    public JwtNotExistException() {
+        super(ExceptionType.JWT_NOT_EXIST);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/exception/JwtTokenExpiredException.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/exception/JwtTokenExpiredException.java
@@ -1,0 +1,14 @@
+package com.uhdyl.backend.global.jwt.exception;
+
+
+import com.uhdyl.backend.global.exception.ExceptionType;
+import lombok.Getter;
+
+@Getter
+public class JwtTokenExpiredException extends JwtAuthenticationException {
+
+    public JwtTokenExpiredException(Throwable cause) {
+        super(cause, ExceptionType.JWT_EXPIRED);
+    }
+
+}

--- a/src/main/java/com/uhdyl/backend/global/jwt/exception/JwtTokenInvalidException.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/exception/JwtTokenInvalidException.java
@@ -1,0 +1,14 @@
+package com.uhdyl.backend.global.jwt.exception;
+
+
+import com.uhdyl.backend.global.exception.ExceptionType;
+
+public class JwtTokenInvalidException extends JwtAuthenticationException {
+    public JwtTokenInvalidException() {
+        super(ExceptionType.JWT_INVALID);
+    }
+
+    public JwtTokenInvalidException(Throwable cause) {
+        super(cause, ExceptionType.JWT_INVALID);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/oauth/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,21 @@
+package com.uhdyl.backend.global.oauth.handler;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public class OAuth2AuthenticationFailureHandler implements AuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception) throws IOException {
+        System.out.println("❌ OAuth2 로그인 실패: " + exception.getMessage());
+        exception.printStackTrace();  // 전체 스택 로그 출력
+
+        // 기본 리다이렉트
+        response.sendRedirect("/login?error");
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/oauth/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,0 +1,57 @@
+package com.uhdyl.backend.global.oauth.handler;
+
+
+import com.uhdyl.backend.global.jwt.JwtHandler;
+import com.uhdyl.backend.global.jwt.JwtUserClaim;
+import com.uhdyl.backend.global.oauth.service.OAuth2UserPrincipal;
+import com.uhdyl.backend.global.oauth.util.RedirectUrlValidator;
+import com.uhdyl.backend.global.oauth.util.StateUtil;
+import com.uhdyl.backend.token.entity.Token;
+import com.uhdyl.backend.user.domain.UserRole;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2AuthenticationSuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtHandler jwtHandler;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException {
+
+
+        String encodedState = request.getParameter("state");
+        String redirectUri = StateUtil.decode(encodedState);
+
+        // 2) 화이트리스트 검증
+        RedirectUrlValidator.validate(redirectUri);
+
+        OAuth2UserPrincipal principal = (OAuth2UserPrincipal) authentication.getPrincipal();
+        Long userId = principal.getUser().getId();
+        UserRole role = principal.getUser().getRole();
+
+        JwtUserClaim jwtUserClaim = new JwtUserClaim(userId,role);
+        Token token = jwtHandler.createTokens(jwtUserClaim);
+
+        // 토큰 붙여서 리다이렉트
+        String redirectUrl = UriComponentsBuilder.fromUriString(redirectUri)
+                .queryParam("accessToken", token.getAccessToken())
+                .queryParam("refreshToken", token.getRefreshToken())
+                .build().toUriString();
+
+        System.out.println(redirectUrl);
+        response.sendRedirect(redirectUrl);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/oauth/resolver/CustomAuthorizationRequestResolver.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/resolver/CustomAuthorizationRequestResolver.java
@@ -1,0 +1,53 @@
+package com.uhdyl.backend.global.oauth.resolver;
+
+
+import com.uhdyl.backend.global.oauth.util.RedirectUrlValidator;
+import com.uhdyl.backend.global.oauth.util.StateUtil;
+import jakarta.servlet.http.HttpServletRequest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.DefaultOAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestResolver;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+
+@Configuration
+public class CustomAuthorizationRequestResolver implements OAuth2AuthorizationRequestResolver {
+    private final DefaultOAuth2AuthorizationRequestResolver delegate;
+
+    public CustomAuthorizationRequestResolver(ClientRegistrationRepository repo) {
+        this.delegate = new DefaultOAuth2AuthorizationRequestResolver(repo, "/oauth2/authorization");
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request) {
+        OAuth2AuthorizationRequest original = delegate.resolve(request);
+        return customizeState(request, original);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest resolve(HttpServletRequest request, String clientRegistrationId) {
+        OAuth2AuthorizationRequest original = delegate.resolve(request, clientRegistrationId);
+        return customizeState(request, original);
+    }
+
+    private OAuth2AuthorizationRequest customizeState(HttpServletRequest request,
+                                                      OAuth2AuthorizationRequest original) {
+        if (original == null) return null;
+
+        // 프론트에서 ?redirect_uri=... 로 넘긴 값
+        String rawRedirect = request.getParameter("redirect_uri");
+        if (rawRedirect == null || rawRedirect.isBlank()) {
+            return original; // redirect_uri 없이도 로그인 가능하도록
+        }
+
+        // 화이트리스트 검증
+        RedirectUrlValidator.validate(rawRedirect);
+
+        // 인코딩
+        String encodedState = StateUtil.encode(rawRedirect);
+
+        return OAuth2AuthorizationRequest.from(original)
+                .state(encodedState)
+                .build();
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/service/CustomOAuth2UserService.java
@@ -1,0 +1,97 @@
+package com.uhdyl.backend.global.oauth.service;
+
+
+import com.uhdyl.backend.global.oauth.user.OAuth2Provider;
+import com.uhdyl.backend.global.oauth.user.OAuth2UserInfo;
+import com.uhdyl.backend.user.domain.User;
+import com.uhdyl.backend.user.domain.UserRole;
+import com.uhdyl.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Map;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        // 1. 유저 정보(attributes) 가져오기
+        Map<String, Object> oAuth2UserAttributes = super.loadUser(userRequest).getAttributes();
+
+        // 2. registrationId 가져오기 (third-party id)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
+        // 3. userNameAttributeName 가져오기
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails()
+                .getUserInfoEndpoint().getUserNameAttributeName();
+
+        String providerId = oAuth2UserAttributes.get(userNameAttributeName).toString();
+
+        // 4. 유저 정보 dto 생성
+        OAuth2UserInfo oAuth2UserInfo = OAuth2UserInfo.of(registrationId, oAuth2UserAttributes);
+
+        // 5. 회원가입 및 로그인
+        User user = getOrSave(oAuth2UserInfo, registrationId, providerId);
+
+        log.info("Access Token: {}", userRequest.getAccessToken().getTokenValue());
+
+        // 추가적인 토큰 정보 로깅
+        log.info("Token Type: {}", userRequest.getAccessToken().getTokenType());
+        log.info("Scopes: {}", userRequest.getAccessToken().getScopes());
+        log.info("Expires At: {}", userRequest.getAccessToken().getExpiresAt());
+
+        // 클라이언트 등록 정보 로깅
+        log.info("Registration ID: {}", userRequest.getClientRegistration().getRegistrationId());
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        // OAuth2User 정보 로깅
+        log.info("OAuth2User Attributes: {}", oAuth2User.getAttributes());
+        // 6. OAuth2User로 반환
+        return new OAuth2UserPrincipal(user, oAuth2UserAttributes, userNameAttributeName);
+
+
+    }
+
+    private User getOrSave(OAuth2UserInfo oAuth2UserInfo, String registrationId, String providerId) {
+
+        OAuth2Provider provider;
+        log.info("oauth2UserInfo: {}", oAuth2UserInfo);
+        if(registrationId.equals("google")) {
+            provider = OAuth2Provider.GOOGLE;
+        }
+        else if(registrationId.equals("kakao")) {
+            provider = OAuth2Provider.KAKAO;
+        } else {
+            provider = null;
+        }
+
+
+
+        User user = userRepository.findByEmail(oAuth2UserInfo.email())
+                .orElseGet(() ->
+                        User.builder()
+                                .email(oAuth2UserInfo.email())
+                                .role(UserRole.USER)
+                                .name(oAuth2UserInfo.name())
+                                .picture(oAuth2UserInfo.profile())
+                                .provider(provider)
+                                .providerId(providerId)
+                                .build()
+                );
+        return userRepository.save(user);
+    }
+
+}

--- a/src/main/java/com/uhdyl/backend/global/oauth/service/OAuth2UserPrincipal.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/service/OAuth2UserPrincipal.java
@@ -1,0 +1,47 @@
+package com.uhdyl.backend.global.oauth.service;
+
+import com.uhdyl.backend.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+@RequiredArgsConstructor
+public class OAuth2UserPrincipal implements  OAuth2User {
+
+    private final User user;
+    private final Map<String, Object> attributes;
+    private final String attributeKey;
+
+
+    @Override
+    public <A> A getAttribute(String name) {
+        return OAuth2User.super.getAttribute(name);
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(
+                new SimpleGrantedAuthority(user.getRole().name())
+        );
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get(attributeKey).toString();
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+}

--- a/src/main/java/com/uhdyl/backend/global/oauth/user/KakaoProperties.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/user/KakaoProperties.java
@@ -1,0 +1,17 @@
+package com.uhdyl.backend.global.oauth.user;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "spring.security.oauth2.client.registration.kakao")
+public class KakaoProperties {
+
+    private String clientId;
+
+    public String getClientId() {
+        return clientId;
+    }
+
+    public void setClientId(String clientId) {
+        this.clientId = clientId;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/oauth/user/OAuth2Provider.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/user/OAuth2Provider.java
@@ -1,0 +1,13 @@
+package com.uhdyl.backend.global.oauth.user;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OAuth2Provider {
+    GOOGLE("google"),
+    KAKAO("kakao");
+
+    private final String registrationId;
+}

--- a/src/main/java/com/uhdyl/backend/global/oauth/user/OAuth2UserInfo.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/user/OAuth2UserInfo.java
@@ -1,0 +1,65 @@
+package com.uhdyl.backend.global.oauth.user;
+
+
+import com.uhdyl.backend.global.exception.BusinessException;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+@Slf4j
+@Builder
+public record OAuth2UserInfo(
+        String name,
+        String email,
+        String profile
+) {
+
+    public static OAuth2UserInfo of(String registrationId, Map<String, Object> attributes) {
+        return switch (registrationId) { // registration id별로 userInfo 생성
+            case "google" -> ofGoogle(attributes);
+            case "kakao" -> ofKakao(attributes);
+            default -> throw new BusinessException(ExceptionType.ILLEGAL_REGISTRATION_ID);
+        };
+    }
+
+    private static OAuth2UserInfo ofGoogle(Map<String, Object> attributes) {
+        log.info("Google User Info: {}", attributes.get("name"));
+        log.info("Google User Info: {}", attributes.get("email"));
+        log.info("Google User Info: {}", attributes.get("picture"));
+
+        return OAuth2UserInfo.builder()
+                .name((String) attributes.get("name"))
+                .email((String) attributes.get("email"))
+                .profile((String) attributes.get("picture"))
+                .build();
+    }
+
+    // TODO : 구글 도입 후에 카카오 도입
+    private static OAuth2UserInfo ofKakao(Map<String, Object> attributes) {
+        log.info("Kakao User Info: {}", attributes.get("kakao_account"));
+        Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+
+        log.info("Kakao User Info: {}", account.get("nickname"));
+        log.info("Kakao User Info: {}", account.get("email"));
+        log.info("Kakao User Info: {}", account.get("profile_image"));
+
+        Map<String, Object> properties = (Map<String, Object>) account.get("profile");
+
+        return OAuth2UserInfo.builder()
+                .name((String) properties.get("nickname"))
+                .email((String) account.get("email"))
+                .profile((String) properties.get("profile_image_url"))
+                .build();
+    }
+
+
+//    public User toEntity() {
+//        return User.builder()
+//                .email(email)
+//                .role(USER)
+//                .provider(provider)
+//                .build()
+//    }
+}

--- a/src/main/java/com/uhdyl/backend/global/oauth/util/RedirectUrlValidator.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/util/RedirectUrlValidator.java
@@ -1,0 +1,18 @@
+package com.uhdyl.backend.global.oauth.util;
+
+import java.util.Set;
+
+public class RedirectUrlValidator {
+
+    private static final Set<String> ALLOWED_PREFIXES = Set.of(
+            "https://babzip.netlify.app",
+            "http://localhost:5173"
+    );
+
+    public static void validate(String uri) {
+        boolean allowed = ALLOWED_PREFIXES.stream().anyMatch(uri::startsWith);
+        if (!allowed) {
+            throw new IllegalArgumentException("허용되지 않은 redirectUri: " + uri);
+        }
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/oauth/util/StateUtil.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/util/StateUtil.java
@@ -1,0 +1,42 @@
+package com.uhdyl.backend.global.oauth.util;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+public class StateUtil {
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    private StateUtil() {}
+
+    /** redirectUri → JSON → Base64URL(without padding) */
+    public static String encode(String redirectUri) {
+        try {
+            String json = MAPPER.writeValueAsString(Map.of("redirectUri", redirectUri));
+            return Base64.getUrlEncoder()
+                    .withoutPadding()
+                    .encodeToString(json.getBytes(StandardCharsets.UTF_8));
+        } catch (Exception e) {
+            throw new IllegalStateException("state encoding 실패", e);
+        }
+    }
+
+    /** Base64URL → JSON → redirectUri */
+    public static String decode(String encodedState) {
+        try {
+            byte[] bytes = Base64.getUrlDecoder().decode(encodedState);
+            JsonNode node = MAPPER.readTree(bytes);
+
+            if (node.hasNonNull("redirectUri")) {
+                return node.get("redirectUri").asText();
+            }
+            throw new IllegalArgumentException("redirectUri 누락");
+        } catch (Exception e) {
+            throw new IllegalArgumentException("state 디코딩 실패", e);
+        }
+    }
+}

--- a/src/main/java/com/uhdyl/backend/token/api/TokenApi.java
+++ b/src/main/java/com/uhdyl/backend/token/api/TokenApi.java
@@ -1,0 +1,43 @@
+package com.uhdyl.backend.token.api;
+
+
+import com.uhdyl.backend.global.config.swagger.SwaggerApiFailedResponse;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.token.dto.request.TokenRequest;
+import com.uhdyl.backend.token.dto.response.TokenResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "토큰 API", description = "토큰 관련 API")
+public interface TokenApi {
+    @Operation(
+            summary = "액세스 토큰, 리프래시 토큰 재발급",
+            description = "사용자는 액세스 토큰이 만료된 경우 액세스 토큰과 리프래시 토큰을 재발급할 수 있습니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = TokenResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = TokenResponse.class,
+                    description = "토큰 재발급 검색 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.JWT_INVALID),
+                    @SwaggerApiFailedResponse(ExceptionType.REFRESH_TOKEN_NOT_EXIST),
+                    @SwaggerApiFailedResponse(ExceptionType.TOKEN_NOT_MATCHED)
+            }
+    )
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ResponseBody<TokenResponse>> refresh(
+            @RequestBody TokenRequest tokenRequest
+    );
+}

--- a/src/main/java/com/uhdyl/backend/token/controller/TokenController.java
+++ b/src/main/java/com/uhdyl/backend/token/controller/TokenController.java
@@ -1,0 +1,32 @@
+package com.uhdyl.backend.token.controller;
+
+
+import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.token.api.TokenApi;
+import com.uhdyl.backend.token.dto.request.TokenRequest;
+import com.uhdyl.backend.token.dto.response.TokenResponse;
+import com.uhdyl.backend.token.entity.Token;
+import com.uhdyl.backend.token.service.TokenService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessResponse;
+
+
+@RestController
+@RequestMapping("/auth/token")
+@RequiredArgsConstructor
+public class TokenController implements TokenApi {
+    private final TokenService tokenService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<ResponseBody<TokenResponse>> refresh(@RequestBody TokenRequest tokenRequest) {
+        Token token = new Token(tokenRequest.accessToken(), tokenRequest.refreshToken());
+        TokenResponse response = tokenService.refresh(token);
+        return ResponseEntity.ok(createSuccessResponse(response));
+    }
+}

--- a/src/main/java/com/uhdyl/backend/token/dto/request/TokenRequest.java
+++ b/src/main/java/com/uhdyl/backend/token/dto/request/TokenRequest.java
@@ -1,0 +1,8 @@
+package com.uhdyl.backend.token.dto.request;
+
+public record TokenRequest (
+    String accessToken,
+    String refreshToken
+){
+
+}

--- a/src/main/java/com/uhdyl/backend/token/dto/response/TokenResponse.java
+++ b/src/main/java/com/uhdyl/backend/token/dto/response/TokenResponse.java
@@ -1,0 +1,6 @@
+package com.uhdyl.backend.token.dto.response;
+
+public record TokenResponse(
+        String accessToken,
+        String refreshToken
+) {}

--- a/src/main/java/com/uhdyl/backend/token/entity/RefreshToken.java
+++ b/src/main/java/com/uhdyl/backend/token/entity/RefreshToken.java
@@ -1,0 +1,37 @@
+package com.uhdyl.backend.token.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+
+@NoArgsConstructor
+@Getter
+@Entity
+public class RefreshToken {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private Long userId;
+
+    private String refreshToken;
+
+    private LocalDateTime expiredAt;
+
+    @Builder
+    public RefreshToken(Long userId, String refreshToken, Long times) {
+        this.userId = userId;
+        this.refreshToken = refreshToken;
+        this.expiredAt = LocalDateTime.now(ZoneId.of("Asia/Seoul"))
+                .plusSeconds(times);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/token/entity/Token.java
+++ b/src/main/java/com/uhdyl/backend/token/entity/Token.java
@@ -1,0 +1,16 @@
+package com.uhdyl.backend.token.entity;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Token {
+    private final String accessToken;
+    private final String refreshToken;
+
+    @Builder
+    public Token(String accessToken, String refreshToken) {
+        this.accessToken = accessToken;
+        this.refreshToken = refreshToken;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/uhdyl/backend/token/repository/RefreshTokenRepository.java
@@ -1,0 +1,18 @@
+package com.uhdyl.backend.token.repository;
+
+import com.uhdyl.backend.token.entity.RefreshToken;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+    Optional<RefreshToken> findByUserId(Long userId);
+    void deleteByUserId(Long userId);
+
+    @Modifying
+    @Query("DELETE FROM RefreshToken r WHERE r.expiredAt <= :timeToDelete")
+    void deleteAllRefreshToken(LocalDateTime timeToDelete);
+}

--- a/src/main/java/com/uhdyl/backend/token/service/TokenService.java
+++ b/src/main/java/com/uhdyl/backend/token/service/TokenService.java
@@ -1,0 +1,41 @@
+package com.uhdyl.backend.token.service;
+
+
+import com.uhdyl.backend.global.exception.BusinessException;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.jwt.JwtHandler;
+import com.uhdyl.backend.global.jwt.JwtUserClaim;
+import com.uhdyl.backend.token.dto.response.TokenResponse;
+import com.uhdyl.backend.token.entity.RefreshToken;
+import com.uhdyl.backend.token.entity.Token;
+import com.uhdyl.backend.token.repository.RefreshTokenRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class TokenService {
+
+    private final JwtHandler jwtHandler;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    @Transactional
+    public TokenResponse refresh(Token token) {
+        JwtUserClaim jwtUserClaim = jwtHandler.getClaims(token.getAccessToken())
+                .orElseThrow(() -> new BusinessException(ExceptionType.JWT_INVALID)); // invalid token
+
+        RefreshToken savedRefreshToken = refreshTokenRepository.findByUserId(jwtUserClaim.userId())
+                .orElseThrow(() -> new BusinessException(ExceptionType.REFRESH_TOKEN_NOT_EXIST)); // not exist token
+
+        if(!token.getRefreshToken().equals(savedRefreshToken.getRefreshToken())) // userId 비교
+            throw new BusinessException(ExceptionType.TOKEN_NOT_MATCHED);
+
+        refreshTokenRepository.deleteByUserId(savedRefreshToken.getUserId());
+
+        Token tokenResponse = jwtHandler.createTokens(jwtUserClaim);
+        return new TokenResponse(tokenResponse.getAccessToken(), tokenResponse.getRefreshToken());
+    }
+
+
+}

--- a/src/main/java/com/uhdyl/backend/user/api/UserApi.java
+++ b/src/main/java/com/uhdyl/backend/user/api/UserApi.java
@@ -1,0 +1,45 @@
+package com.uhdyl.backend.user.api;
+
+
+import com.uhdyl.backend.global.aop.AssignUserId;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiFailedResponse;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.ResponseBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Tag(name = "사용자 API", description = "사용자 관련 API")
+public interface UserApi {
+
+    @Operation(
+            summary = "로그아웃",
+            description = "사용자는 로그아웃을 진행합니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "로그아웃 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+            }
+    )
+    @AssignUserId
+    @DeleteMapping("/logout")
+    @PreAuthorize(" isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Void>> logout(@Parameter(hidden = true) Long userId);
+
+
+
+
+}

--- a/src/main/java/com/uhdyl/backend/user/controller/UserController.java
+++ b/src/main/java/com/uhdyl/backend/user/controller/UserController.java
@@ -1,0 +1,34 @@
+package com.uhdyl.backend.user.controller;
+
+
+import com.uhdyl.backend.global.aop.AssignUserId;
+import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.user.api.UserApi;
+import com.uhdyl.backend.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessResponse;
+
+
+@RestController
+@RequestMapping("/user")
+@RequiredArgsConstructor
+public class UserController implements UserApi {
+
+    private final UserService userService;
+
+    @AssignUserId
+    @DeleteMapping("/logout")
+    @PreAuthorize(" isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Void>> logout(Long userId){
+        userService.logout(userId);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+
+}

--- a/src/main/java/com/uhdyl/backend/user/domain/User.java
+++ b/src/main/java/com/uhdyl/backend/user/domain/User.java
@@ -1,0 +1,45 @@
+package com.uhdyl.backend.user.domain;
+
+import com.uhdyl.backend.global.base.BaseEntity;
+import com.uhdyl.backend.global.oauth.user.OAuth2Provider;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Getter
+    private Long id;
+
+    @Column(unique = true)
+    private String email;
+
+    @Enumerated(value = EnumType.STRING)
+    @Getter
+    private UserRole role;
+
+    private String name;
+
+    private String picture;
+
+    @Enumerated(value = EnumType.STRING)
+    private OAuth2Provider provider;
+
+    private String providerId;
+
+    @Builder
+    public User(String email, UserRole role, String name, String picture, OAuth2Provider provider, String providerId) {
+        this.email = email;
+        this.role = role;
+        this.name = name;
+        this.picture = picture;
+        this.provider = provider;
+        this.providerId = providerId;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/user/domain/UserRole.java
+++ b/src/main/java/com/uhdyl/backend/user/domain/UserRole.java
@@ -1,0 +1,15 @@
+package com.uhdyl.backend.user.domain;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+public enum UserRole {
+
+    USER("ROLE_USER"),
+    FARMER("ROLE_FARMER");
+
+    private final String key;
+}

--- a/src/main/java/com/uhdyl/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/uhdyl/backend/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.user.repository;
+
+import com.uhdyl.backend.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByEmail(String email);
+}

--- a/src/main/java/com/uhdyl/backend/user/service/UserService.java
+++ b/src/main/java/com/uhdyl/backend/user/service/UserService.java
@@ -1,0 +1,34 @@
+package com.uhdyl.backend.user.service;
+
+
+import com.uhdyl.backend.global.exception.BusinessException;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.token.repository.RefreshTokenRepository;
+import com.uhdyl.backend.user.domain.User;
+import com.uhdyl.backend.user.domain.UserRole;
+import com.uhdyl.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+
+    public boolean isFarmer(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(()->new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        return user.getRole().equals(UserRole.FARMER);
+    }
+
+    @Transactional
+    public void logout(Long userId){
+        refreshTokenRepository.deleteByUserId(userId);
+    }
+
+
+}


### PR DESCRIPTION
## What is this PR?🔍
- Spring Security를 사용해 OAuth2.0 로그인을 구현했습니다.
- 로그인 성공 시 JWT를 발급하여 인증 및 인가에 사용합니다.
- AOP를 사용하여 userId를 자동으로 주입받을 수 있도록 합니다.
- 
## Changes💻
- 커스텀 어노테이션 `@AssignUserId`를 컨트롤러의 메서드에 사용하여 엔드포인트를 호출한 유저의 userId(PK)를 주입받을 수 있습니다.
>     
    @AssignUserId
    @DeleteMapping("/logout")
    @PreAuthorize(" isAuthenticated() and hasAuthority('USER')")
    public ResponseEntity<ResponseBody<Void>> logout(Long userId){
        userService.logout(userId);
        return ResponseEntity.ok(createSuccessResponse());
    }

- Token 도메인을 추가했습니다.
- RefreshToken 도메인을 추가하여 로그인한 사용자의 RefreshToken을 관리합니다. RefreshToken 재발급 Api도 추가했습니다.
- 사용자의 권한을 계층구조로 FARMER>USER로 설정했습니다. FARMER는 USER 권한이 필요한 행동을 모두 수행할 수 있지만 USER는 FARMER 권한이 필요한 행동을 수행하지 못합니다.
- 프론트엔드는 OAuth2.0 로그인 요청 시 `state` 필드에 `redirectUrl`을 포함하여 서버로 전달합니다.
- 서버는 해당 `redirectUrl`이 사전에 등록된 화이트리스트에 포함되어 있는지 검증합니다.
- 검증에 성공하면, `accessToken`과 `refreshToken`을 `redirectUrl`의 쿼리 파라미터로 추가하여 리디렉션합니다.
- 현재는 구글과 카카오로 소셜 로그인 및 로그아웃이 가능합니다.
- 로그아웃 시 사용자의 리프래시 토큰을 DB에서 제거합니다. 프론트 측의 액세스 토큰 제거도 함께 이루어져야 합니다.
- User 도메인을 추가했습니다.

## ScreenShot📷
