### PR TITLE
chore: 채팅방 생성 시 채팅 메시지를 전달하지 않도록 수정

### DIFF
--- a/src/main/java/com/uhdyl/backend/chat/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/uhdyl/backend/chat/dto/response/ChatRoomResponse.java
@@ -8,15 +8,13 @@ import java.util.List;
 public record ChatRoomResponse(
         Long chatRoomId,
         Long userId,
-        Long sellerId,
-        List<ChatMessageResponse> message
+        Long sellerId
 ) {
-    public static ChatRoomResponse to(ChatRoom chatRoom, List<ChatMessage> message) {
+    public static ChatRoomResponse to(ChatRoom chatRoom) {
         return new ChatRoomResponse(
                 chatRoom.getId(),
                 chatRoom.getUser1(),
-                chatRoom.getUser2(),
-                message.stream().map(ChatMessageResponse::to).toList()
+                chatRoom.getUser2()
         );
     }
 

--- a/src/main/java/com/uhdyl/backend/chat/service/ChatRoomService.java
+++ b/src/main/java/com/uhdyl/backend/chat/service/ChatRoomService.java
@@ -2,18 +2,14 @@ package com.uhdyl.backend.chat.service;
 
 import com.uhdyl.backend.chat.domain.ChatRoom;
 import com.uhdyl.backend.chat.dto.response.ChatRoomResponse;
-import com.uhdyl.backend.chat.repository.ChatMessageRepository;
 import com.uhdyl.backend.chat.repository.ChatRoomRepository;
 import com.uhdyl.backend.global.exception.BusinessException;
 import com.uhdyl.backend.global.exception.ExceptionType;
-import com.uhdyl.backend.user.domain.User;
-import com.uhdyl.backend.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
-import java.util.Collections;
 import java.util.Objects;
 
 @Service
@@ -22,7 +18,6 @@ import java.util.Objects;
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
-    private final ChatMessageRepository chatMessageRepository;
 
 
     @Transactional
@@ -43,7 +38,7 @@ public class ChatRoomService {
 
         return chatRoomRepository.findByUser1AndUser2(user1, user2)
                 .map(
-                        room -> ChatRoomResponse.to(room, chatMessageRepository.findMessagesWithUserByChatRoom(room)))
+                        ChatRoomResponse::to)
                 .orElseGet(
                         () -> {
                             return ChatRoomResponse.to(
@@ -52,8 +47,7 @@ public class ChatRoomService {
                                                     .user1(user1)
                                                     .user2(user2)
                                                     .build()
-                                            )
-                                    , Collections.emptyList());
+                                            ));
 
                         }
                 );


### PR DESCRIPTION
## What is this PR?🔍
- 관심사의 분리를 위해 채팅방 생성 시 이전 채팅 메시지를 응답하지 않도록 변경했습니다.
- 이전 채팅 메시지는 이전 PR의 채팅 메시지를 불러오는 api를 통해 불러올 수 있습니다.
## Changes💻
- 채팅방 생성 후 응답에서 채팅 메시지를 제거했습니다.
-
-

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified chat room responses by removing message details from chat room data.
  * Chat room creation and retrieval now return only basic chat room information without associated messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->