### PR TITLE
feat: 이미지 업로드, 삭제 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,6 +66,9 @@ dependencies {
     // Jsoup
     implementation 'org.jsoup:jsoup:1.21.1'
 
+    // Cloudinary
+    implementation 'com.cloudinary:cloudinary-http44:1.37.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/uhdyl/backend/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/ChatMessageRepository.java
@@ -9,4 +9,5 @@ import java.util.List;
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, CustomChatMessageRepository{
     List<ChatMessage> findMessagesWithUserByChatRoom(ChatRoom chatRoom);
 
+    ChatMessage findByPublicId(String publicId);
 }

--- a/src/main/java/com/uhdyl/backend/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/ChatRoomRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
     Optional<ChatRoom> findByUser1AndUser2(Long user1, Long user2);
+
+    ChatRoom findByName(String name);
 }

--- a/src/main/java/com/uhdyl/backend/chat/repository/CustomChatMessageRepository.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/CustomChatMessageRepository.java
@@ -8,4 +8,5 @@ import java.time.LocalDateTime;
 
 public interface CustomChatMessageRepository {
     Page<ChatMessageResponse> findChatMessages(Long roomId, Pageable pageable, LocalDateTime startDateTime);
+    boolean existsByUserIdAndPublicId(Long userId, String publicId);
 }

--- a/src/main/java/com/uhdyl/backend/chat/repository/CustomChatMessageRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/CustomChatMessageRepositoryImpl.java
@@ -46,4 +46,18 @@ public class CustomChatMessageRepositoryImpl implements CustomChatMessageReposit
         List<ChatMessageResponse> response = ChatMessageResponse.to(messages);
         return new PageImpl<>(response, pageable, total);
     }
+
+    @Override
+    public boolean existsByUserIdAndPublicId(Long userId, String publicId) {
+
+        QChatMessage qChatMessage = QChatMessage.chatMessage;
+
+        return jpaQueryFactory
+                .selectFrom(qChatMessage)
+                .where(
+                        qChatMessage.user.id.eq(userId),
+                        qChatMessage.publicId.eq(publicId)
+                )
+                .fetchOne() != null;
+    }
 }

--- a/src/main/java/com/uhdyl/backend/global/config/image/CloudinaryConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/image/CloudinaryConfig.java
@@ -1,0 +1,27 @@
+package com.uhdyl.backend.global.config.image;
+
+import com.cloudinary.Cloudinary;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@RequiredArgsConstructor
+@EnableConfigurationProperties(CloudinaryProperties.class)
+public class CloudinaryConfig {
+
+    private final CloudinaryProperties cloudinaryProperties;
+
+    @Bean
+    public Cloudinary cloudinary() {
+        Map<String, String> config = new HashMap<>();
+        config.put("cloud_name", cloudinaryProperties.getCloudName());
+        config.put("api_key", cloudinaryProperties.getApiKey());
+        config.put("api_secret", cloudinaryProperties.getApiSecret());
+        return new Cloudinary(config);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/global/config/image/CloudinaryProperties.java
+++ b/src/main/java/com/uhdyl/backend/global/config/image/CloudinaryProperties.java
@@ -1,0 +1,14 @@
+package com.uhdyl.backend.global.config.image;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Getter
+@Setter
+@ConfigurationProperties(prefix = "cloudinary")
+public class CloudinaryProperties {
+    private String cloudName;
+    private String apiKey;
+    private String apiSecret;
+}

--- a/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
+++ b/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
@@ -40,6 +40,11 @@ public enum ExceptionType {
     WS_ROOM_ACCESS_DENIED(FORBIDDEN, "WS003", "채팅방에 대한 접근 권한이 없습니다"),
     WS_INVALID_ROOM_PATH(BAD_REQUEST, "WS004", "잘못된 채팅방 경로입니다"),
 
+    // Image
+    IMAGE_ACCESS_DENIED(FORBIDDEN, "I001", "해당 이미지에 대한 권한이 없습니다."),
+    IMAGE_UPLOAD_FAILED(INTERNAL_SERVER_ERROR, "I002", "이미지 업로드에 실패했습니다."),
+    IMAGE_DELETE_FAILED(INTERNAL_SERVER_ERROR, "I003", "이미지 삭제에 실패했습니다."),
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/uhdyl/backend/image/domain/Image.java
+++ b/src/main/java/com/uhdyl/backend/image/domain/Image.java
@@ -1,0 +1,22 @@
+package com.uhdyl.backend.image.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+@Entity
+public class Image {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String ImageUrl;
+
+    private Long imageOrder;
+
+    private String publicId;
+
+
+}

--- a/src/main/java/com/uhdyl/backend/image/domain/ImageType.java
+++ b/src/main/java/com/uhdyl/backend/image/domain/ImageType.java
@@ -1,0 +1,21 @@
+package com.uhdyl.backend.image.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum ImageType {
+    USER_IMAGE("user-image", "사용자 프로필 이미지"),
+    PRODUCT_IMAGE("product-image", "상품 이미지"),
+    CHAT_IMAGE("chat-image", "채팅 이미지"),
+    REVIEW_IMAGE("review-image", "리뷰 이미지");
+
+    private final String key;
+    private final String description;
+
+    ImageType(String key, String description) {
+        this.key = key;
+        this.description = description;
+    }
+}
+
+

--- a/src/main/java/com/uhdyl/backend/image/dto/request/ImageDeleteRequest.java
+++ b/src/main/java/com/uhdyl/backend/image/dto/request/ImageDeleteRequest.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.image.dto.request;
+
+import com.uhdyl.backend.image.domain.ImageType;
+
+public record ImageDeleteRequest(
+        ImageType imageType,
+        String imageUrl,
+        String publicId
+) {
+}

--- a/src/main/java/com/uhdyl/backend/image/dto/response/ImageSavedSuccessResponse.java
+++ b/src/main/java/com/uhdyl/backend/image/dto/response/ImageSavedSuccessResponse.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.image.dto.response;
+
+public record ImageSavedSuccessResponse(
+        String imageUrl,
+        String publicId
+) {
+    public static ImageSavedSuccessResponse to(String url, String publicId){
+        return new ImageSavedSuccessResponse(url, publicId);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/image/repository/CustomImageRepository.java
+++ b/src/main/java/com/uhdyl/backend/image/repository/CustomImageRepository.java
@@ -1,0 +1,5 @@
+package com.uhdyl.backend.image.repository;
+
+public interface CustomImageRepository {
+    boolean existsByUserIdAndPublicId(Long userId, String publicId);
+}

--- a/src/main/java/com/uhdyl/backend/image/repository/CustomImageRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/image/repository/CustomImageRepositoryImpl.java
@@ -1,0 +1,24 @@
+package com.uhdyl.backend.image.repository;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.uhdyl.backend.image.domain.QImage;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class CustomImageRepositoryImpl implements CustomImageRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    // TODO: Product 도메인 개발 후 쿼리 변경하기
+    @Override
+    public boolean existsByUserIdAndPublicId(Long userId, String publicId) {
+        QImage qImage = QImage.image;
+
+        return jpaQueryFactory
+                .selectFrom(qImage)
+                .where(
+                    qImage.publicId.eq(publicId)
+                )
+                .fetchOne() != null;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/image/repository/ImageRepository.java
+++ b/src/main/java/com/uhdyl/backend/image/repository/ImageRepository.java
@@ -1,0 +1,8 @@
+package com.uhdyl.backend.image.repository;
+
+import com.uhdyl.backend.image.domain.Image;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ImageRepository extends JpaRepository<Image, Long>, CustomImageRepository {
+    void deleteByPublicId(String publicId);
+}

--- a/src/main/java/com/uhdyl/backend/image/service/ImageService.java
+++ b/src/main/java/com/uhdyl/backend/image/service/ImageService.java
@@ -1,0 +1,83 @@
+package com.uhdyl.backend.image.service;
+
+import com.cloudinary.Cloudinary;
+import com.cloudinary.utils.ObjectUtils;
+import com.uhdyl.backend.chat.domain.ChatMessage;
+import com.uhdyl.backend.chat.repository.ChatMessageRepository;
+import com.uhdyl.backend.global.exception.BusinessException;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.image.domain.ImageType;
+import com.uhdyl.backend.image.dto.response.ImageSavedSuccessResponse;
+import com.uhdyl.backend.image.repository.ImageRepository;
+import com.uhdyl.backend.user.domain.User;
+import com.uhdyl.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class ImageService {
+
+    private final Cloudinary cloudinary;
+    private final ImageRepository imageRepository;
+    private final UserRepository userRepository;
+    private final ChatMessageRepository chatMessageRepository;
+
+    public ImageSavedSuccessResponse uploadImage(MultipartFile image, String folderPath){
+        try {
+            Map<?, ?> result = cloudinary.uploader().upload(
+                    image.getBytes(),
+                    Map.of(
+                            "folder", folderPath,
+                            "public_id", UUID.randomUUID().toString()
+                    )
+            );
+            return ImageSavedSuccessResponse.to(result.get("secure_url").toString(), result.get("public_id").toString());
+        } catch (IOException e) {
+            throw new BusinessException(ExceptionType.IMAGE_UPLOAD_FAILED);
+        }
+    }
+
+    @Transactional
+    public void deleteImage(ImageType imageType, String publicId, Long userId){
+
+        // TODO: 리뷰 도메인 추가 시 로직 추가하기
+        switch (imageType){
+            case USER_IMAGE -> {
+                if(userRepository.existsByIdAndPublicId(userId, publicId)){
+                    User user = userRepository.findById(userId)
+                            .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+                    user.deleteImage();
+                }
+            }
+
+            case PRODUCT_IMAGE -> {
+                if (imageRepository.existsByUserIdAndPublicId(userId, publicId)){
+                    imageRepository.deleteByPublicId(publicId);
+                }
+            }
+
+            case CHAT_IMAGE -> {
+                if (chatMessageRepository.existsByUserIdAndPublicId(userId, publicId)){
+                    ChatMessage chatMessage = chatMessageRepository.findByPublicId(publicId);
+                    chatMessage.deleteImage();
+                }
+            }
+        }
+
+        try {
+            cloudinary.uploader().destroy(publicId, ObjectUtils.emptyMap());
+        } catch (IOException e) {
+            throw new BusinessException(ExceptionType.IMAGE_DELETE_FAILED);
+        }
+
+
+    }
+
+}

--- a/src/main/java/com/uhdyl/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/uhdyl/backend/user/repository/UserRepository.java
@@ -7,4 +7,6 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+
+    boolean existsByIdAndPublicId(Long id, String publicId);
 }


### PR DESCRIPTION
## What is this PR?🔍
- 이미지 업로드 삭제를 개발했습니다.
- 각 이미지는 도메인에 따라 분리된 디렉터리에 저장됩니다. (채팅 이미지 -> chat 디렉터리, 프로필 이미지 -> profile 디렉터리, 상품 이미지 -> product 디렉터리)

- 현재 이미지 저장 로직은 다음과 같습니다.
1. 프론트는 채팅, 상품, 리뷰 생성 api 호출 전 먼저 이미지 업로드 api를 호출
2. 이미지 업로드 api는 이미지를 클라우드에 저장(api 호출 시 어떤 도메인의 이미지인지 함께 전달)
3. 이미지 업로드 api는 `이미지가 저장된 url`과 `publicId`를 프론트에게 반환
4. 프론트는 채팅, 상품, 리뷰 생성 api를 호출할 때 이미지 업로드 api를 호출할 때 전달받은` 이미지가 저장된 url`을 함께 전달
5. 백엔드는 채팅, 상품, 리뷰 생성 api를 통해 DB에 정보 저장

- cloudinary는 이미지를 삭제하기 위해 각 이미지마다 발급되는 고유한 `publicId`를 사용합니다.
- publicId는 uuid를 통해 백엔드에서 생성합니다. 같은 도메인에서는 `publicId`는 겹치지 않습니다.
- 현재 이미지 삭제 시 로직은 다음과 같습니다.
1. 프론트는 이미지 업로드 api를 통해 전달받은 `publicId`, `이미지가 저장된 url`, `이미지의 도메인(enum으로 정의된 형식에 맞게 전달)`을 이미지 삭제 시 전달
3. 백엔드는 삭제하려는 이미지가 사용자가 소유한 사진인지 검증
4. 검증 후 이미지 삭제

## Changes💻

-
-
-

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 이미지 업로드 및 삭제를 위한 REST API가 추가되었습니다. 사용자, 채팅, 상품 이미지 업로드 및 삭제를 지원합니다.
  * Cloudinary 연동이 도입되어 이미지 파일 저장 및 관리를 제공합니다.
  * 이미지 타입, 삭제 요청/응답 등 이미지 관련 DTO와 엔티티가 추가되었습니다.

* **버그 수정**
  * 해당 없음.

* **기타**
  * 이미지 관련 예외 타입이 추가되어 오류 상황에 대한 안내가 강화되었습니다.
  * 일부 저장소(Repository)에 이미지 및 채팅 메시지 조회/삭제를 위한 메서드가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->