### PR TITLE
feat: 이미지 예외 추가 및 오류 수정, 의존 파일 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/chat/domain/ChatMessage.java
+++ b/src/main/java/com/uhdyl/backend/chat/domain/ChatMessage.java
@@ -29,11 +29,19 @@ public class ChatMessage extends BaseEntity {
 
     private String imageUrl;
 
+    private String publicId;
+
     @Builder
-    public ChatMessage(ChatRoom chatRoom, User user, String message, String imageUrl) {
+    public ChatMessage(ChatRoom chatRoom, User user, String message, String imageUrl, String publicId) {
         this.chatRoom = chatRoom;
         this.user = user;
         this.message = message;
         this.imageUrl = imageUrl;
+        this.publicId = publicId;
+    }
+
+    public void deleteImage(){
+        this.imageUrl = null;
+        this.publicId = null;
     }
 }

--- a/src/main/java/com/uhdyl/backend/chat/domain/ChatRoom.java
+++ b/src/main/java/com/uhdyl/backend/chat/domain/ChatRoom.java
@@ -22,9 +22,12 @@ public class ChatRoom extends BaseEntity {
 
     private Long user2;
 
+    private String name;
+
     @Builder
-    public ChatRoom(Long user1, Long user2) {
+    public ChatRoom(Long user1, Long user2, String name) {
         this.user1 = user1;
         this.user2 = user2;
+        this.name = name;
     }
 }

--- a/src/main/java/com/uhdyl/backend/chat/dto/request/ChatMessageRequest.java
+++ b/src/main/java/com/uhdyl/backend/chat/dto/request/ChatMessageRequest.java
@@ -9,6 +9,7 @@ public class ChatMessageRequest {
 
     private String message;
     private String imageUrl;
+    private String publicId;
 
     public void setMessage(String message) {
         this.message = Jsoup.clean(message, Safelist.basic());

--- a/src/main/java/com/uhdyl/backend/chat/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/uhdyl/backend/chat/dto/response/ChatRoomResponse.java
@@ -8,13 +8,15 @@ import java.util.List;
 public record ChatRoomResponse(
         Long chatRoomId,
         Long userId,
-        Long sellerId
+        Long sellerId,
+        String name
 ) {
     public static ChatRoomResponse to(ChatRoom chatRoom) {
         return new ChatRoomResponse(
                 chatRoom.getId(),
                 chatRoom.getUser1(),
-                chatRoom.getUser2()
+                chatRoom.getUser2(),
+                chatRoom.getName()
         );
     }
 

--- a/src/main/java/com/uhdyl/backend/chat/service/ChatMessageService.java
+++ b/src/main/java/com/uhdyl/backend/chat/service/ChatMessageService.java
@@ -41,8 +41,7 @@ public class ChatMessageService {
             throw new BusinessException(ExceptionType.WS_ROOM_ACCESS_DENIED);
         }
 
-        if(request.getMessage() == null || request.getMessage().isBlank())
-            request.setMessage(request.getMessage());
+        request.setMessage(request.getMessage());
 
         ChatMessage chatMessage = ChatMessage.builder()
                 .message(request.getMessage())

--- a/src/main/java/com/uhdyl/backend/chat/service/ChatMessageService.java
+++ b/src/main/java/com/uhdyl/backend/chat/service/ChatMessageService.java
@@ -41,13 +41,15 @@ public class ChatMessageService {
             throw new BusinessException(ExceptionType.WS_ROOM_ACCESS_DENIED);
         }
 
-        request.setMessage(request.getMessage());
+        if(request.getMessage() == null || request.getMessage().isBlank())
+            request.setMessage(request.getMessage());
 
         ChatMessage chatMessage = ChatMessage.builder()
                 .message(request.getMessage())
                 .user(user)
                 .imageUrl(request.getImageUrl())
                 .chatRoom(chatRoom)
+                .publicId(request.getPublicId())
                 .build();
         chatMessageRepository.save(chatMessage);
 

--- a/src/main/java/com/uhdyl/backend/chat/service/ChatRoomService.java
+++ b/src/main/java/com/uhdyl/backend/chat/service/ChatRoomService.java
@@ -2,14 +2,18 @@ package com.uhdyl.backend.chat.service;
 
 import com.uhdyl.backend.chat.domain.ChatRoom;
 import com.uhdyl.backend.chat.dto.response.ChatRoomResponse;
+import com.uhdyl.backend.chat.repository.ChatMessageRepository;
 import com.uhdyl.backend.chat.repository.ChatRoomRepository;
 import com.uhdyl.backend.global.exception.BusinessException;
 import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.user.domain.User;
+import com.uhdyl.backend.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.Collections;
 import java.util.Objects;
 
 @Service
@@ -18,6 +22,8 @@ import java.util.Objects;
 public class ChatRoomService {
 
     private final ChatRoomRepository chatRoomRepository;
+    private final ChatMessageRepository chatMessageRepository;
+    private final UserRepository userRepository;
 
 
     @Transactional
@@ -36,6 +42,10 @@ public class ChatRoomService {
         if(Objects.equals(user1, user2))
             throw new BusinessException(ExceptionType.CANT_CREATE_CHATROOM);
 
+        // TODO: 채팅방 이름을 어떻게 정할지 프론트와 상의하기
+        User user = userRepository.findById(user2)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
         return chatRoomRepository.findByUser1AndUser2(user1, user2)
                 .map(
                         ChatRoomResponse::to)
@@ -46,6 +56,7 @@ public class ChatRoomService {
                                             ChatRoom.builder()
                                                     .user1(user1)
                                                     .user2(user2)
+                                                    .name(user.getName())
                                                     .build()
                                             ));
 

--- a/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
+++ b/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
@@ -44,6 +44,8 @@ public enum ExceptionType {
     IMAGE_ACCESS_DENIED(FORBIDDEN, "I001", "해당 이미지에 대한 권한이 없습니다."),
     IMAGE_UPLOAD_FAILED(INTERNAL_SERVER_ERROR, "I002", "이미지 업로드에 실패했습니다."),
     IMAGE_DELETE_FAILED(INTERNAL_SERVER_ERROR, "I003", "이미지 삭제에 실패했습니다."),
+    INVALID_IMAGE_FILE(FORBIDDEN, "I004", "허용되지 않은 이미지입니다."),
+    IMAGE_SIZE_EXCEEDED(FORBIDDEN, "I005", "이미지 용량이 초과했습니다."),
 
     ;
 

--- a/src/main/java/com/uhdyl/backend/image/controller/ImageController.java
+++ b/src/main/java/com/uhdyl/backend/image/controller/ImageController.java
@@ -43,7 +43,7 @@ public class ImageController {
     @PostMapping("/image/chat")
     @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
     public ResponseEntity<ResponseBody<ImageSavedSuccessResponse>> uploadChatMessageImage(
-            Long roomId,
+            @RequestParam Long roomId,
             @RequestParam MultipartFile image
     ){
         return ResponseEntity.ok(createSuccessResponse(
@@ -61,9 +61,9 @@ public class ImageController {
     ){
 
         List<ImageSavedSuccessResponse> response = new ArrayList<>();
-        for(int i = 1; i <= images.size(); i++){
+        for(int i = 0; i < images.size(); i++){
             response.add(
-                    imageService.uploadImage(images.get(i), "product/" + i + "/")
+                    imageService.uploadImage(images.get(i), "product/" + (i + 1) + "/")
             );
         }
 
@@ -82,9 +82,7 @@ public class ImageController {
         @RequestBody List<ImageDeleteRequest> request,
         Long userId
     ){
-        request.forEach(imageDeleteRequest -> {
-            imageService.deleteImage(imageDeleteRequest.imageType(), imageDeleteRequest.publicId(), userId);
-        });
+        imageService.deleteImage(request, userId);
         return ResponseEntity.ok(createSuccessResponse());
     }
 

--- a/src/main/java/com/uhdyl/backend/image/domain/Image.java
+++ b/src/main/java/com/uhdyl/backend/image/domain/Image.java
@@ -4,19 +4,31 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class Image {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String ImageUrl;
+    private String imageUrl;
 
     private Long imageOrder;
 
     private String publicId;
+
+    @Builder
+    public Image(String imageUrl, Long imageOrder, String publicId) {
+        this.imageUrl = imageUrl;
+        this.imageOrder = imageOrder;
+        this.publicId = publicId;
+    }
 
 
 }

--- a/src/main/java/com/uhdyl/backend/image/service/ImageService.java
+++ b/src/main/java/com/uhdyl/backend/image/service/ImageService.java
@@ -7,6 +7,7 @@ import com.uhdyl.backend.chat.repository.ChatMessageRepository;
 import com.uhdyl.backend.global.exception.BusinessException;
 import com.uhdyl.backend.global.exception.ExceptionType;
 import com.uhdyl.backend.image.domain.ImageType;
+import com.uhdyl.backend.image.dto.request.ImageDeleteRequest;
 import com.uhdyl.backend.image.dto.response.ImageSavedSuccessResponse;
 import com.uhdyl.backend.image.repository.ImageRepository;
 import com.uhdyl.backend.user.domain.User;
@@ -17,6 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
@@ -30,6 +32,13 @@ public class ImageService {
     private final ChatMessageRepository chatMessageRepository;
 
     public ImageSavedSuccessResponse uploadImage(MultipartFile image, String folderPath){
+
+        if(image == null || image.isEmpty())
+            throw new BusinessException(ExceptionType.INVALID_IMAGE_FILE);
+
+        if(image.getSize() > 1024 * 1024 * 5)
+            throw new BusinessException(ExceptionType.IMAGE_SIZE_EXCEEDED);
+
         try {
             Map<?, ?> result = cloudinary.uploader().upload(
                     image.getBytes(),
@@ -38,6 +47,10 @@ public class ImageService {
                             "public_id", UUID.randomUUID().toString()
                     )
             );
+
+            if(result.get("secure_url") == null || result.get("public_id") == null)
+                throw new BusinessException(ExceptionType.IMAGE_UPLOAD_FAILED);
+
             return ImageSavedSuccessResponse.to(result.get("secure_url").toString(), result.get("public_id").toString());
         } catch (IOException e) {
             throw new BusinessException(ExceptionType.IMAGE_UPLOAD_FAILED);
@@ -45,38 +58,44 @@ public class ImageService {
     }
 
     @Transactional
-    public void deleteImage(ImageType imageType, String publicId, Long userId){
+    public void deleteImage(List<ImageDeleteRequest> request, Long userId){
 
         // TODO: 리뷰 도메인 추가 시 로직 추가하기
-        switch (imageType){
-            case USER_IMAGE -> {
-                if(userRepository.existsByIdAndPublicId(userId, publicId)){
+        request.forEach(imageDeleteRequest -> {
+            ImageType imageType = imageDeleteRequest.imageType();
+            String publicId = imageDeleteRequest.publicId();
+            switch (imageType){
+                case USER_IMAGE -> {
+                    if(!userRepository.existsByIdAndPublicId(userId, publicId))
+                        throw new BusinessException(ExceptionType.IMAGE_ACCESS_DENIED);
+
                     User user = userRepository.findById(userId)
                             .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
                     user.deleteImage();
                 }
-            }
 
-            case PRODUCT_IMAGE -> {
-                if (imageRepository.existsByUserIdAndPublicId(userId, publicId)){
+                case PRODUCT_IMAGE -> {
+                    if (!imageRepository.existsByUserIdAndPublicId(userId, publicId))
+                        throw new BusinessException(ExceptionType.IMAGE_ACCESS_DENIED);
+
                     imageRepository.deleteByPublicId(publicId);
                 }
-            }
 
-            case CHAT_IMAGE -> {
-                if (chatMessageRepository.existsByUserIdAndPublicId(userId, publicId)){
+                case CHAT_IMAGE -> {
+                    if (!chatMessageRepository.existsByUserIdAndPublicId(userId, publicId))
+                        throw new BusinessException(ExceptionType.IMAGE_ACCESS_DENIED);
+
                     ChatMessage chatMessage = chatMessageRepository.findByPublicId(publicId);
                     chatMessage.deleteImage();
                 }
             }
-        }
 
-        try {
-            cloudinary.uploader().destroy(publicId, ObjectUtils.emptyMap());
-        } catch (IOException e) {
-            throw new BusinessException(ExceptionType.IMAGE_DELETE_FAILED);
-        }
-
+            try {
+                cloudinary.uploader().destroy(publicId, ObjectUtils.emptyMap());
+            } catch (IOException e) {
+                throw new BusinessException(ExceptionType.IMAGE_DELETE_FAILED);
+            }
+        });
 
     }
 

--- a/src/main/java/com/uhdyl/backend/user/domain/User.java
+++ b/src/main/java/com/uhdyl/backend/user/domain/User.java
@@ -33,6 +33,8 @@ public class User extends BaseEntity {
 
     private String providerId;
 
+    private String publicId;
+
     @Builder
     public User(String email, UserRole role, String name, String picture, OAuth2Provider provider, String providerId) {
         this.email = email;
@@ -41,5 +43,10 @@ public class User extends BaseEntity {
         this.picture = picture;
         this.provider = provider;
         this.providerId = providerId;
+    }
+
+    public void deleteImage(){
+        this.picture = null;
+        this.publicId = null;
     }
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -34,6 +34,10 @@ spring:
         format_sql: false
         highlight_sql: true
         default_batch_fetch_size: 100
+  servlet:
+    multipart:
+      max-file-size: 5MB     # 한 파일 최대 크기
+      max-request-size: 50MB  # 전체 요청 최대 크기 (여러 파일 합산)
 
 logging:
   level:

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,6 +28,10 @@ spring:
         format_sql: false
         highlight_sql: true
         default_batch_fetch_size: 100
+  servlet:
+    multipart:
+      max-file-size: 10MB     # 한 파일 최대 크기
+      max-request-size: 100MB  # 전체 요청 최대 크기 (여러 파일 합산)
 
 logging:
   level:


### PR DESCRIPTION
## What is this PR?🔍
- 이미지 로직의 예외를 추가하고 발생할 수 있는 오류를 수정했습니다.
- image 도메인을 의존하는 코드들을 추가했습니다.
- 
## Changes💻
- 이미지 업로드 용량을 이미지 당 5MB로 제한합니다.
- 여러 장 업로드 시 50MB로 제한합니다.
-
-

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 채팅 메시지 및 사용자, 이미지 관련 엔티티에 이미지 식별자(publicId) 필드가 추가되었습니다.
  * 채팅방에 이름(name) 필드가 추가되어 상대방 이름으로 채팅방이 생성됩니다.
  * 이미지 삭제 시 여러 이미지를 한 번에 삭제할 수 있도록 개선되었습니다.

* **버그 수정**
  * 이미지 업로드 시 파일 크기 및 유효성 검사가 추가되어, 허용되지 않은 이미지나 용량 초과 이미지는 업로드할 수 없습니다.

* **설정**
  * 개발 및 로컬 환경에서 파일 업로드 최대 크기와 요청 크기 제한이 적용되었습니다.

* **예외 처리**
  * 이미지 파일 관련 예외(허용되지 않은 파일, 용량 초과) 유형이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->