### PR TITLE
feat: 리뷰 도메인 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
+++ b/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
@@ -50,6 +50,7 @@ public enum ExceptionType {
     // Review
     REVIEW_NOT_FOUND(NOT_FOUND, "R001", "리뷰가 존재하지 않습니다."),
     CANT_REVIEW_MYSELF(FORBIDDEN, "R002", "자신에게 리뷰를 작성할 수 없습니다."),
+    CANT_DELETE_REVIEW(FORBIDDEN, "R003", "다른 사용자의 리뷰를 삭제할 수 없습니다,"),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
+++ b/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
@@ -47,6 +47,9 @@ public enum ExceptionType {
     INVALID_IMAGE_FILE(FORBIDDEN, "I004", "허용되지 않은 이미지입니다."),
     IMAGE_SIZE_EXCEEDED(FORBIDDEN, "I005", "이미지 용량이 초과했습니다."),
 
+    // Review
+    REVIEW_NOT_FOUND(NOT_FOUND, "R001", "리뷰가 존재하지 않습니다."),
+    CANT_REVIEW_MYSELF(FORBIDDEN, "R002", "자신에게 리뷰를 작성할 수 없습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/uhdyl/backend/review/api/ReviewApi.java
+++ b/src/main/java/com/uhdyl/backend/review/api/ReviewApi.java
@@ -1,0 +1,123 @@
+package com.uhdyl.backend.review.api;
+
+import com.uhdyl.backend.global.aop.AssignUserId;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiFailedResponse;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.review.dto.request.ReviewCreateRequest;
+import com.uhdyl.backend.review.dto.response.ReviewResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "라뷰 API", description = "리뷰 관련 API")
+public interface ReviewApi {
+
+    @Operation(
+            summary = "리뷰 작성",
+            description = "사용자는 리뷰를 작성합니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "리뷰 작성 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.CANT_REVIEW_MYSELF),
+            }
+    )
+    @PostMapping("/review")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Void>> createReview(
+            @Parameter(hidden = true) Long userId,
+            @RequestBody ReviewCreateRequest reviewCreateRequest
+    );
+
+
+    @Operation(
+            summary = "구매자 본인이 작성한 리뷰 페이징 조회",
+            description = "구매자는 자신이 작성한 리뷰를 조회할 수 있습니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ReviewResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    responsePage = ReviewResponse.class,
+                    description = "리뷰 페이징 조회 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+            }
+    )
+    @AssignUserId
+    @GetMapping("/review/me")
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Page<ReviewResponse>>> getMyReviews(
+            @Parameter(hidden = true) Long userId,
+            @ParameterObject
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    );
+
+
+    @Operation(
+            summary = "구매자가 판매자에게 작성한 리뷰 페이징 조회",
+            description = "판매자는 페이지로 작성된 리뷰를 조회할 수 있습니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ReviewResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    responsePage = ReviewResponse.class,
+                    description = "리뷰 페이징 조회 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+            }
+    )
+    @AssignUserId
+    @GetMapping("/review")
+    @PreAuthorize("isAuthenticated() and hasAuthority('FARMER')")
+    public ResponseEntity<ResponseBody<Page<ReviewResponse>>> getAllReviews(
+            @Parameter(hidden = true) Long userId,
+            @ParameterObject
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    );
+
+
+    @Operation(
+            summary = "리뷰 삭제",
+            description = "사용자는 자신이 작성한 리뷰를 삭제할 수 있습니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "리뷰 삭제 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.REVIEW_NOT_FOUND),
+            }
+    )
+    @DeleteMapping("/review/{reviewId}")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Void>> deleteReview(
+            @Parameter(hidden = true) Long userId,
+            @PathVariable Long reviewId
+    );
+}

--- a/src/main/java/com/uhdyl/backend/review/controller/ReviewController.java
+++ b/src/main/java/com/uhdyl/backend/review/controller/ReviewController.java
@@ -1,0 +1,82 @@
+package com.uhdyl.backend.review.controller;
+
+import com.uhdyl.backend.global.aop.AssignUserId;
+import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.review.api.ReviewApi;
+import com.uhdyl.backend.review.dto.request.ReviewCreateRequest;
+import com.uhdyl.backend.review.dto.response.ReviewResponse;
+import com.uhdyl.backend.review.service.ReviewService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class ReviewController implements ReviewApi {
+
+    private final ReviewService reviewService;
+
+    /**
+     * 리뷰 작성 api
+     */
+    @PostMapping("/review")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Void>> createReview(
+            Long userId,
+            @RequestBody ReviewCreateRequest reviewCreateRequest
+    )
+    {
+        reviewService.createReview(userId, reviewCreateRequest);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    /**
+     *  자신이 작성한 리뷰 페이징 조회 api
+     *  구매자가 사용할 api
+     */
+    @AssignUserId
+    @GetMapping("/review/me")
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Page<ReviewResponse>>> getMyReviews(
+            Long userId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ){
+        return ResponseEntity.ok(createSuccessResponse(reviewService.getMyReviews(userId, pageable)));
+    }
+
+    /**
+     *  자신에게 작성된 리뷰 페이징 조회 api
+     *  판매자가 사용할 api
+     */
+    @AssignUserId
+    @GetMapping("/review")
+    @PreAuthorize("isAuthenticated() and hasAuthority('FARMER')")
+    public ResponseEntity<ResponseBody<Page<ReviewResponse>>> getAllReviews(
+            Long userId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ){
+        return ResponseEntity.ok(createSuccessResponse(reviewService.getAllReviews(userId, pageable)));
+    }
+
+    /**
+     * 리뷰 삭제 api
+     */
+    @DeleteMapping("/review/{reviewId}")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Void>> deleteReview(
+            Long userId,
+            @PathVariable Long reviewId
+    ) {
+        reviewService.deleteReview(userId, reviewId);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+}

--- a/src/main/java/com/uhdyl/backend/review/domain/Review.java
+++ b/src/main/java/com/uhdyl/backend/review/domain/Review.java
@@ -1,0 +1,45 @@
+package com.uhdyl.backend.review.domain;
+
+import com.uhdyl.backend.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long Id;
+
+    private String content;
+
+    private String imageUrl;
+
+    private String publicId;
+
+    private Long rating;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    private Long targetUserId;
+
+    @Builder
+    public Review(User user, String content, String imageUrl, String publicId, Long rating, Long targetUserId) {
+        this.user = user;
+        this.content = content;
+        this.imageUrl = imageUrl;
+        this.publicId = publicId;
+        this.rating = rating;
+        this.targetUserId = targetUserId;
+    }
+
+    public void setUser(User user){
+        this.user = user;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/review/domain/Review.java
+++ b/src/main/java/com/uhdyl/backend/review/domain/Review.java
@@ -1,5 +1,6 @@
 package com.uhdyl.backend.review.domain;
 
+import com.uhdyl.backend.global.base.BaseEntity;
 import com.uhdyl.backend.user.domain.User;
 import jakarta.persistence.*;
 import lombok.Builder;
@@ -9,11 +10,11 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
-public class Review {
+public class Review extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long Id;
+    private Long id;
 
     private String content;
 

--- a/src/main/java/com/uhdyl/backend/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/uhdyl/backend/review/dto/request/ReviewCreateRequest.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.review.dto.request;
+
+public record ReviewCreateRequest (
+        String content,
+        Long rating,
+        String imageUrl,
+        String publicId,
+        Long targetUserId
+){
+}

--- a/src/main/java/com/uhdyl/backend/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/uhdyl/backend/review/dto/response/ReviewResponse.java
@@ -1,0 +1,19 @@
+package com.uhdyl.backend.review.dto.response;
+
+import com.uhdyl.backend.review.domain.Review;
+
+public record ReviewResponse(
+        Long Id,
+        String content,
+        Long rating,
+        String imageUrl
+){
+    public static ReviewResponse to(Review review){
+        return new ReviewResponse(
+                review.getId(),
+                review.getContent(),
+                review.getRating(),
+                review.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/uhdyl/backend/review/repository/CustomReviewRepository.java
+++ b/src/main/java/com/uhdyl/backend/review/repository/CustomReviewRepository.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.review.repository;
+
+import com.uhdyl.backend.review.dto.response.ReviewResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomReviewRepository {
+    Page<ReviewResponse> getMyReviews(Long userId, Pageable pageable);
+    Page<ReviewResponse> getAllReviews(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/uhdyl/backend/review/repository/CustomReviewRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/review/repository/CustomReviewRepositoryImpl.java
@@ -1,0 +1,69 @@
+package com.uhdyl.backend.review.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.uhdyl.backend.review.domain.QReview;
+import com.uhdyl.backend.review.domain.Review;
+import com.uhdyl.backend.review.dto.response.ReviewResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomReviewRepositoryImpl implements CustomReviewRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public Page<ReviewResponse> getMyReviews(Long userId, Pageable pageable) {
+        QReview qReview = QReview.review;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(qReview.user.id.eq(userId));
+
+        List<Review> reviews = jpaQueryFactory
+                .selectFrom(qReview)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = jpaQueryFactory
+                .select(qReview.count())
+                .from(qReview)
+                .where(builder)
+                .fetchOne();
+
+        List<ReviewResponse> response = reviews.stream().map(ReviewResponse::to).toList();
+
+        return new PageImpl<>(response, pageable, total != null ? total : 0);
+    }
+
+    @Override
+    public Page<ReviewResponse> getAllReviews(Long userId, Pageable pageable) {
+        QReview qReview = QReview.review;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(qReview.targetUserId.eq(userId));
+
+        List<Review> reviews = jpaQueryFactory
+                .selectFrom(qReview)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = jpaQueryFactory
+                .select(qReview.count())
+                .from(qReview)
+                .where(builder)
+                .fetchOne();
+
+        List<ReviewResponse> response = reviews.stream().map(ReviewResponse::to).toList();
+
+        return new PageImpl<>(response, pageable, total != null ? total : 0);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/review/repository/ReviewRepository.java
+++ b/src/main/java/com/uhdyl/backend/review/repository/ReviewRepository.java
@@ -1,0 +1,7 @@
+package com.uhdyl.backend.review.repository;
+
+import com.uhdyl.backend.review.domain.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long>, CustomReviewRepository {
+}

--- a/src/main/java/com/uhdyl/backend/review/service/ReviewService.java
+++ b/src/main/java/com/uhdyl/backend/review/service/ReviewService.java
@@ -1,0 +1,75 @@
+package com.uhdyl.backend.review.service;
+
+import com.uhdyl.backend.global.exception.BusinessException;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.review.domain.Review;
+import com.uhdyl.backend.review.dto.request.ReviewCreateRequest;
+import com.uhdyl.backend.review.dto.response.ReviewResponse;
+import com.uhdyl.backend.review.repository.ReviewRepository;
+import com.uhdyl.backend.user.domain.User;
+import com.uhdyl.backend.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Objects;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createReview(Long userId, ReviewCreateRequest request){
+        User user = userRepository.findById(userId).
+                orElseThrow(()->new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        if(!userRepository.existsById(request.targetUserId()))
+            throw new BusinessException(ExceptionType.USER_NOT_FOUND);
+
+        if(Objects.equals(user.getId(), request.targetUserId()))
+            throw new BusinessException(ExceptionType.CANT_REVIEW_MYSELF);
+
+        Review review = Review.builder()
+                .user(user)
+                .imageUrl(request.imageUrl())
+                .content(request.content())
+                .publicId(request.publicId())
+                .rating(request.rating())
+                .targetUserId(request.targetUserId())
+                .build();
+        user.addReview(review);
+        reviewRepository.save(review);
+    }
+
+    @Transactional
+    public void deleteReview(Long userId, Long reviewId){
+        if(!userRepository.existsById(userId))
+            throw new BusinessException(ExceptionType.USER_NOT_FOUND);
+
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.REVIEW_NOT_FOUND));
+        reviewRepository.deleteById(reviewId);
+        review.getUser().deleteReview(review);
+    }
+
+    public Page<ReviewResponse> getMyReviews(Long userId, Pageable pageable){
+        if(!userRepository.existsById(userId))
+            throw new BusinessException(ExceptionType.USER_NOT_FOUND);
+
+        return reviewRepository.getMyReviews(userId, pageable);
+    }
+
+    public Page<ReviewResponse> getAllReviews(Long userId, Pageable pageable){
+        if(!userRepository.existsById(userId))
+            throw new BusinessException(ExceptionType.USER_NOT_FOUND);
+
+        return reviewRepository.getAllReviews(userId, pageable);
+    }
+
+}

--- a/src/main/java/com/uhdyl/backend/review/service/ReviewService.java
+++ b/src/main/java/com/uhdyl/backend/review/service/ReviewService.java
@@ -54,6 +54,10 @@ public class ReviewService {
 
         Review review = reviewRepository.findById(reviewId)
                 .orElseThrow(() -> new BusinessException(ExceptionType.REVIEW_NOT_FOUND));
+
+        if (!Objects.equals(review.getUser().getId(), userId)) {
+            throw new BusinessException(ExceptionType.CANT_DELETE_REVIEW);
+        }
         reviewRepository.deleteById(reviewId);
         review.getUser().deleteReview(review);
     }

--- a/src/main/java/com/uhdyl/backend/user/domain/User.java
+++ b/src/main/java/com/uhdyl/backend/user/domain/User.java
@@ -64,5 +64,6 @@ public class User extends BaseEntity {
 
     public void deleteReview(Review review){
         this.reviews.remove(review);
+        review.setUser(null);
     }
 }

--- a/src/main/java/com/uhdyl/backend/user/domain/User.java
+++ b/src/main/java/com/uhdyl/backend/user/domain/User.java
@@ -8,6 +8,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -39,7 +40,7 @@ public class User extends BaseEntity {
     private String publicId;
 
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<Review> reviews;
+    private List<Review> reviews = new ArrayList<>();
 
     @Builder
     public User(String email, UserRole role, String name, String picture, OAuth2Provider provider, String providerId) {

--- a/src/main/java/com/uhdyl/backend/user/domain/User.java
+++ b/src/main/java/com/uhdyl/backend/user/domain/User.java
@@ -2,10 +2,13 @@ package com.uhdyl.backend.user.domain;
 
 import com.uhdyl.backend.global.base.BaseEntity;
 import com.uhdyl.backend.global.oauth.user.OAuth2Provider;
+import com.uhdyl.backend.review.domain.Review;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Entity
 @NoArgsConstructor
@@ -35,6 +38,9 @@ public class User extends BaseEntity {
 
     private String publicId;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Review> reviews;
+
     @Builder
     public User(String email, UserRole role, String name, String picture, OAuth2Provider provider, String providerId) {
         this.email = email;
@@ -48,5 +54,14 @@ public class User extends BaseEntity {
     public void deleteImage(){
         this.picture = null;
         this.publicId = null;
+    }
+
+    public void addReview(Review review){
+        this.reviews.add(review);
+        review.setUser(this);
+    }
+
+    public void deleteReview(Review review){
+        this.reviews.remove(review);
     }
 }


### PR DESCRIPTION
## What is this PR?🔍
- 리뷰 도메인을 추가합니다.

## Changes💻
- 리뷰 작성, 조회, 삭제 api가 추가되었습니다.
- User 도메인에 편의 메서드를 추가하여 양방향 연관관계로 설계했습니다.
- 구매자가 리뷰 작성 시 어떤 판매자에게 작성하는 리뷰인지를 표시하기 위해 `Long tagetUserId;` 필드를 추가했습니다.
- 리뷰 조회는 구매자와 판매자 api를 분리했습니다.
- 구매자는 자신이 작성한 리뷰를 조회할 수 있습니다.
- 판매자는 구매자가 자신에게 작성한 리뷰를 조회할 수 있습니다.

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 리뷰 생성, 조회(내가 작성한 리뷰, 내가 받은 리뷰), 삭제 기능이 추가되었습니다.
  * 리뷰 작성 시 평점, 내용, 이미지 업로드가 가능합니다.
  * 자신에게 리뷰를 작성할 수 없도록 제한됩니다.
  * 리뷰 목록은 페이지네이션 및 최신순 정렬을 지원합니다.

* **버그 수정**
  * 리뷰 관련 예외 처리(리뷰 미존재, 자기 자신 리뷰 금지, 타인 리뷰 삭제 금지)가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->