### PR TITLE
feat: 마이페이지 api 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,8 +70,7 @@ dependencies {
     implementation 'com.cloudinary:cloudinary-http44:1.37.0'
 
     // JsonNullable
-    implementation 'org.openapitools:jackson-databind-nullable:0.2.4'
-
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.6'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,10 @@ dependencies {
     // Cloudinary
     implementation 'com.cloudinary:cloudinary-http44:1.37.0'
 
+    // JsonNullable
+    implementation 'org.openapitools:jackson-databind-nullable:0.2.4'
+
+
 }
 
 tasks.named('test') {

--- a/src/main/java/com/uhdyl/backend/global/config/json/JsonConfig.java
+++ b/src/main/java/com/uhdyl/backend/global/config/json/JsonConfig.java
@@ -1,0 +1,24 @@
+package com.uhdyl.backend.global.config.json;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.openapitools.jackson.nullable.JsonNullableModule;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JsonConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper()
+                .setSerializationInclusion(JsonInclude.Include.ALWAYS)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS, SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+                .registerModules(new JsonNullableModule(), new JavaTimeModule());
+    }
+
+}

--- a/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
+++ b/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
@@ -30,6 +30,10 @@ public enum ExceptionType {
     // User
     USER_NOT_FOUND(NOT_FOUND, "U001","사용자가 존재하지 않습니다"),
     USER_NOT_FARMER(FORBIDDEN, "U002", "판매자만 가능한 기능입니다."),
+    USER_NICKNAME_DUPLICATED(FORBIDDEN, "U003", "중복된 닉네임을 사용할 수 없습니다."),
+    BBAT_NOT_UPDATED(UNAUTHORIZED, "U004", "판매자 밭 정보가 입력되지 않았습니다."),
+
+
 
     // Chat
     CANT_CREATE_CHATROOM(FORBIDDEN, "CH001", "채팅방을 생성할 수 없습니다."),

--- a/src/main/java/com/uhdyl/backend/token/dto/response/TokenResponse.java
+++ b/src/main/java/com/uhdyl/backend/token/dto/response/TokenResponse.java
@@ -1,6 +1,12 @@
 package com.uhdyl.backend.token.dto.response;
 
+import com.uhdyl.backend.token.domain.Token;
+
 public record TokenResponse(
         String accessToken,
         String refreshToken
-) {}
+) {
+    public static TokenResponse to(Token token){
+        return new TokenResponse(token.getAccessToken(), token.getRefreshToken());
+    }
+}

--- a/src/main/java/com/uhdyl/backend/user/api/UserApi.java
+++ b/src/main/java/com/uhdyl/backend/user/api/UserApi.java
@@ -142,6 +142,7 @@ public interface UserApi {
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NICKNAME_DUPLICATED)
             }
     )
     @AssignUserId

--- a/src/main/java/com/uhdyl/backend/user/api/UserApi.java
+++ b/src/main/java/com/uhdyl/backend/user/api/UserApi.java
@@ -7,15 +7,21 @@ import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
 import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
 import com.uhdyl.backend.global.exception.ExceptionType;
 import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.token.dto.response.TokenResponse;
 import com.uhdyl.backend.user.dto.request.LocationRequest;
+import com.uhdyl.backend.user.dto.request.UserNicknameUpdateRequest;
+import com.uhdyl.backend.user.dto.request.UserProfileUpdateRequest;
+import com.uhdyl.backend.user.dto.response.UserProfileResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.*;
+
 
 @Tag(name = "사용자 API", description = "사용자 관련 API")
 public interface UserApi {
@@ -54,5 +60,95 @@ public interface UserApi {
     @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
     @PostMapping("/location")
     ResponseEntity<ResponseBody<Void>> saveLocation(@RequestBody LocationRequest request,
-                                                    @Parameter(hidden = true) Long userId);
+                                                             @Parameter(hidden = true) Long userId);
+
+
+    @Operation(
+            summary = "밭 등록 후 판매자 권한(FARMER) 획득",
+            description = "사용자는 밭 등록 후 판매자 권한(FARMER)를 획득하고 액세스 토큰과 리프래시 토큰을 재발급 받습니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = TokenResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = TokenResponse.class,
+                    description = "판매자 권한(FARMER) 획득 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.BBAT_NOT_UPDATED),
+            }
+    )
+    @AssignUserId
+    @PostMapping("/complete-registration")
+    @PreAuthorize(" isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<TokenResponse>> completeRegistration(
+            @Parameter(hidden = true) Long userId
+    );
+
+
+    @Operation(
+            summary =  "닉네임 변경",
+            description = "사용자는 초기 닉네임을 변경합니다. 이후의 닉네임 변경은 프로필 정보 수정 api를 통해 진행합니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(description = "닉네임 변경 성공"),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NICKNAME_DUPLICATED)
+            }
+    )
+    @AssignUserId
+    @PostMapping("/nickname")
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Void>> updateNickname(
+            @Parameter(hidden = true) Long userId,
+            @RequestBody UserNicknameUpdateRequest request
+    );
+
+
+    @Operation(
+            summary = "사용자 프로필 조회",
+            description = "사용자는 자신의 프로필 정보를 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = UserProfileResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = UserProfileResponse.class,
+                    description = "프로필 조회 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+            }
+    )
+    @AssignUserId
+    @GetMapping("/profile")
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<UserProfileResponse>> getProfile(
+            @Parameter(hidden = true) Long userId
+    );
+
+
+    @Operation(
+            summary = "사용자 프로필 수정",
+            description = "사용자는 자신의 프로필 정보를 수정합니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "프로필 수정 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+            }
+    )
+    @AssignUserId
+    @PatchMapping("/profile")
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Void>> updateProfile(
+            @Parameter(hidden = true) Long userId,
+            @RequestBody UserProfileUpdateRequest request
+    );
 }

--- a/src/main/java/com/uhdyl/backend/user/controller/UserController.java
+++ b/src/main/java/com/uhdyl/backend/user/controller/UserController.java
@@ -3,18 +3,19 @@ package com.uhdyl.backend.user.controller;
 
 import com.uhdyl.backend.global.aop.AssignUserId;
 import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.token.domain.Token;
+import com.uhdyl.backend.token.dto.response.TokenResponse;
 import com.uhdyl.backend.user.api.UserApi;
 import com.uhdyl.backend.user.dto.request.LocationRequest;
+import com.uhdyl.backend.user.dto.request.UserNicknameUpdateRequest;
+import com.uhdyl.backend.user.dto.request.UserProfileUpdateRequest;
+import com.uhdyl.backend.user.dto.response.UserProfileResponse;
 import com.uhdyl.backend.user.service.UserService;
 import io.swagger.v3.oas.annotations.Parameter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessResponse;
 
@@ -40,6 +41,48 @@ public class UserController implements UserApi {
     public ResponseEntity<ResponseBody<Void>> saveLocation(@RequestBody LocationRequest request,
                                                            @Parameter(hidden = true) Long userId){
         userService.saveLocation(userId, request.getLocation_x(), request.getLocation_y());
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    /**
+     * 구매자가 처음으로 판매자로 전환 시 권한을 변경하고 토큰을 재발급하는 api
+     */
+    @AssignUserId
+    @PostMapping("/complete-registration")
+    @PreAuthorize(" isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<TokenResponse>> completeRegistration(
+            Long userId
+    ){
+        Token token = userService.completeRegistration(userId);
+        return ResponseEntity.ok(createSuccessResponse(TokenResponse.to(token)));
+    }
+
+    @AssignUserId
+    @PostMapping("/nickname")
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Void>> updateNickname(
+            Long userId,
+            @RequestBody UserNicknameUpdateRequest request
+    ){
+        userService.updateNickname(userId, request);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    @AssignUserId
+    @GetMapping("/profile")
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<UserProfileResponse>> getProfile(Long userId){
+        return ResponseEntity.ok(createSuccessResponse(userService.getProfile(userId)));
+    }
+
+    @AssignUserId
+    @PatchMapping("/profile")
+    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    public ResponseEntity<ResponseBody<Void>> updateProfile(
+            Long userId,
+            @RequestBody UserProfileUpdateRequest request
+    ){
+        userService.updateProfile(userId, request);
         return ResponseEntity.ok(createSuccessResponse());
     }
 }

--- a/src/main/java/com/uhdyl/backend/user/domain/User.java
+++ b/src/main/java/com/uhdyl/backend/user/domain/User.java
@@ -89,7 +89,7 @@ public class User extends BaseEntity {
     public void updateProfile(JsonNullable<String> picture, JsonNullable<String> nickname){
 
         if(picture.isPresent())
-            this.publicId = picture.get();
+            this.picture = picture.get();
         if(nickname.isPresent())
             this.nickname = nickname.get();
     }

--- a/src/main/java/com/uhdyl/backend/user/domain/User.java
+++ b/src/main/java/com/uhdyl/backend/user/domain/User.java
@@ -8,6 +8,7 @@ import java.math.BigDecimal;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.openapitools.jackson.nullable.JsonNullable;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,6 +31,9 @@ public class User extends BaseEntity {
     private UserRole role;
 
     private String name;
+
+    @Column(unique = true)
+    private String nickname;
 
     private String picture;
 
@@ -76,5 +80,27 @@ public class User extends BaseEntity {
     public void deleteReview(Review review){
         this.reviews.remove(review);
         review.setUser(null);
+    }
+
+    public void updateNickname(String nickname){
+        this.nickname = nickname;
+    }
+
+    public void updateProfile(JsonNullable<String> picture, JsonNullable<String> nickname){
+
+        if(picture.isPresent())
+            this.publicId = picture.get();
+        if(nickname.isPresent())
+            this.nickname = nickname.get();
+    }
+
+    public void updateUserToFarmer(){
+        this.role = UserRole.FARMER;
+    }
+
+    public boolean isBBatRegistered(){
+        if(this.location_x == null || this.location_y == null)
+            return false;
+        return true;
     }
 }

--- a/src/main/java/com/uhdyl/backend/user/dto/request/UserNicknameUpdateRequest.java
+++ b/src/main/java/com/uhdyl/backend/user/dto/request/UserNicknameUpdateRequest.java
@@ -1,0 +1,6 @@
+package com.uhdyl.backend.user.dto.request;
+
+public record UserNicknameUpdateRequest (
+        String nickname
+){
+}

--- a/src/main/java/com/uhdyl/backend/user/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/com/uhdyl/backend/user/dto/request/UserProfileUpdateRequest.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.user.dto.request;
+
+import org.openapitools.jackson.nullable.JsonNullable;
+
+public record UserProfileUpdateRequest (
+        JsonNullable<String> profileImageUrl,
+        JsonNullable<String> nickname
+){
+
+}

--- a/src/main/java/com/uhdyl/backend/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/uhdyl/backend/user/dto/response/UserProfileResponse.java
@@ -1,0 +1,17 @@
+package com.uhdyl.backend.user.dto.response;
+
+import com.uhdyl.backend.user.domain.User;
+
+public record UserProfileResponse(
+        String profileImageUrl,
+        String nickname,
+        String role
+) {
+    public static UserProfileResponse to(User user){
+        return new UserProfileResponse(
+                user.getPicture(),
+                user.getNickname(),
+                user.getRole().name()
+        );
+    }
+}

--- a/src/main/java/com/uhdyl/backend/user/repository/UserRepository.java
+++ b/src/main/java/com/uhdyl/backend/user/repository/UserRepository.java
@@ -9,4 +9,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
 
     boolean existsByIdAndPublicId(Long id, String publicId);
+
+    boolean existsByNickname(String nickname);
 }

--- a/src/main/java/com/uhdyl/backend/user/service/UserService.java
+++ b/src/main/java/com/uhdyl/backend/user/service/UserService.java
@@ -75,7 +75,7 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
 
-        if(userRepository.existsByNickname(request.nickname().toString()))
+        if(userRepository.existsByNickname(request.nickname().get()))
             throw new BusinessException(ExceptionType.USER_NICKNAME_DUPLICATED);
 
         user.updateProfile(request.profileImageUrl(), request.nickname());

--- a/src/main/java/com/uhdyl/backend/user/service/UserService.java
+++ b/src/main/java/com/uhdyl/backend/user/service/UserService.java
@@ -1,11 +1,16 @@
 package com.uhdyl.backend.user.service;
 
-
 import com.uhdyl.backend.global.exception.BusinessException;
 import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.jwt.JwtHandler;
+import com.uhdyl.backend.global.jwt.JwtUserClaim;
+import com.uhdyl.backend.token.domain.Token;
 import com.uhdyl.backend.token.repository.RefreshTokenRepository;
 import com.uhdyl.backend.user.domain.User;
 import com.uhdyl.backend.user.domain.UserRole;
+import com.uhdyl.backend.user.dto.request.UserNicknameUpdateRequest;
+import com.uhdyl.backend.user.dto.request.UserProfileUpdateRequest;
+import com.uhdyl.backend.user.dto.response.UserProfileResponse;
 import com.uhdyl.backend.user.repository.UserRepository;
 import java.math.BigDecimal;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +19,12 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class UserService {
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtHandler jwtHandler;
 
     public boolean isFarmer(Long userId) {
         User user = userRepository.findById(userId)
@@ -42,5 +49,48 @@ public class UserService {
 
         user.updateLocation(locationX, locationY);
         userRepository.save(user);
+    }
+
+    @Transactional
+    public void updateNickname(Long userId, UserNicknameUpdateRequest request){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        if(userRepository.existsByNickname(request.nickname()))
+            throw new BusinessException(ExceptionType.USER_NICKNAME_DUPLICATED);
+
+        user.updateNickname(request.nickname());
+    }
+
+    public UserProfileResponse getProfile(Long userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        return UserProfileResponse.to(user);
+    }
+
+
+    @Transactional
+    public void updateProfile(Long userId, UserProfileUpdateRequest request){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        if(userRepository.existsByNickname(request.nickname().toString()))
+            throw new BusinessException(ExceptionType.USER_NICKNAME_DUPLICATED);
+
+        user.updateProfile(request.profileImageUrl(), request.nickname());
+    }
+
+    @Transactional
+    public Token completeRegistration(Long userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        if(!user.isBBatRegistered())
+            throw new BusinessException(ExceptionType.BBAT_NOT_UPDATED);
+
+        user.updateUserToFarmer();
+        JwtUserClaim claim = new JwtUserClaim(userId, user.getRole());
+        return jwtHandler.createTokens(claim);
     }
 }


### PR DESCRIPTION
## What is this PR?🔍
- 마이페이지 api를 추가합니다.
- 프로필 정보 조회, 프로필 정보 수정, 닉네임 변경, 권한 변경 api를 추가합니다.
## Changes💻
- PATCH 호출 시 사용자가 해당 필드의 값을 null로 보낸건지, 해당 필드를 포함하여 보내지 않은건지를 구별하기 위해 `JsonNullable`을 사용합니다. 아래 링크를 참고했습니다.
- https://steam-egg.tistory.com/30
- 사용자가 판매자로 등록하기 위해 밭의 위치를 등록 후 `completeRegistration`을 호출하여 권한을 FARMER로 변경합니다. 이 때 액세스 토큰과 리프래시 토큰을 재발급 받습니다.
- 

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신규 기능**
  * 사용자 닉네임 중복 확인 및 변경 기능이 추가되었습니다.
  * 사용자 프로필 조회 및 수정 기능이 도입되었습니다.
  * 회원가입 완료 시 역할 전환(구매자 → 판매자) 및 토큰 재발급 기능이 추가되었습니다.

* **버그 수정**
  * JSON 직렬화/역직렬화 과정에서 누락된 값 및 날짜 처리 방식이 개선되었습니다.

* **기타**
  * 사용자 관련 API 엔드포인트가 확장되었습니다.
  * 예외 유형이 추가되어 오류 메시지가 더 명확해졌습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->