### PR TITLE
chore: 유저 api 수정

### DIFF
--- a/src/main/java/com/uhdyl/backend/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/uhdyl/backend/chat/controller/ChatMessageController.java
@@ -44,7 +44,7 @@ public class ChatMessageController {
     }
 
     @GetMapping("/chat/room/{roomId}/messages")
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<Page<ChatMessageResponse>>> findChatMessages(
             @PathVariable Long roomId,
             @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 10) Pageable pageable,

--- a/src/main/java/com/uhdyl/backend/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/uhdyl/backend/chat/controller/ChatRoomController.java
@@ -24,7 +24,7 @@ public class ChatRoomController {
 
     @PostMapping("/chat/room")
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<ChatRoomResponse>> createChatRoom(
             // TODO: 현재는 상대방의 ID를 전달받지만, 프론트 연결 시에는 상품의 PK 또는 상품의 제목과 닉네임을 받아서 채팅방을 만드는 구조로 변경해야됨
             @RequestBody ChatRoomRequest request,

--- a/src/main/java/com/uhdyl/backend/global/jwt/JwtAuthentication.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/JwtAuthentication.java
@@ -22,7 +22,7 @@ public record JwtAuthentication(
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singleton(new SimpleGrantedAuthority(this.role().name()));
+        return Collections.singleton(new SimpleGrantedAuthority(this.role().getKey()));
     }
 
     @Override

--- a/src/main/java/com/uhdyl/backend/global/jwt/JwtHandler.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/JwtHandler.java
@@ -48,6 +48,8 @@ public class JwtHandler {
         String refreshToken = UUID.randomUUID().toString();
         long refreshTokenExpireIn = jwtProperties.getRefreshTokenExpireIn();
         RefreshToken refreshTokenEntity = new RefreshToken(jwtUserClaim.userId(), refreshToken, refreshTokenExpireIn);
+        if(refreshTokenRepository.existsByUserId(jwtUserClaim.userId()))
+            refreshTokenRepository.deleteByUserId(jwtUserClaim.userId());
         refreshTokenRepository.save(refreshTokenEntity);
 
         return Token.builder()

--- a/src/main/java/com/uhdyl/backend/global/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/uhdyl/backend/global/oauth/service/CustomOAuth2UserService.java
@@ -89,6 +89,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
                                 .picture(oAuth2UserInfo.profile())
                                 .provider(provider)
                                 .providerId(providerId)
+                                .mode("구매자")
                                 .build()
                 );
         return userRepository.save(user);

--- a/src/main/java/com/uhdyl/backend/image/controller/ImageController.java
+++ b/src/main/java/com/uhdyl/backend/image/controller/ImageController.java
@@ -27,7 +27,7 @@ public class ImageController {
      */
     @PostMapping("/image/user")
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<ImageSavedSuccessResponse>> uploadProfileImage(
             Long userId,
             @RequestParam MultipartFile image
@@ -41,7 +41,7 @@ public class ImageController {
      * 채팅 이미지 업로드 api
      */
     @PostMapping("/image/chat")
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<ImageSavedSuccessResponse>> uploadChatMessageImage(
             @RequestParam Long roomId,
             @RequestParam MultipartFile image
@@ -55,7 +55,7 @@ public class ImageController {
      * 상품 이미지 업로드 api
      */
     @PostMapping("/image/product")
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<List<ImageSavedSuccessResponse>>> uploadProductImage(
             @RequestParam List<MultipartFile> images
     ){
@@ -77,7 +77,7 @@ public class ImageController {
      */
     @DeleteMapping("/image")
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<Void>> deleteImage(
         @RequestBody List<ImageDeleteRequest> request,
         Long userId

--- a/src/main/java/com/uhdyl/backend/review/controller/ReviewController.java
+++ b/src/main/java/com/uhdyl/backend/review/controller/ReviewController.java
@@ -28,7 +28,7 @@ public class ReviewController implements ReviewApi {
      */
     @PostMapping("/review")
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<Void>> createReview(
             Long userId,
             @RequestBody ReviewCreateRequest reviewCreateRequest
@@ -44,7 +44,7 @@ public class ReviewController implements ReviewApi {
      */
     @AssignUserId
     @GetMapping("/review/me")
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<Page<ReviewResponse>>> getMyReviews(
             Long userId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
@@ -58,7 +58,7 @@ public class ReviewController implements ReviewApi {
      */
     @AssignUserId
     @GetMapping("/review")
-    @PreAuthorize("isAuthenticated() and hasAuthority('FARMER')")
+    @PreAuthorize("isAuthenticated() and hasRole('FARMER')")
     public ResponseEntity<ResponseBody<Page<ReviewResponse>>> getAllReviews(
             Long userId,
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
@@ -71,7 +71,7 @@ public class ReviewController implements ReviewApi {
      */
     @DeleteMapping("/review/{reviewId}")
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<Void>> deleteReview(
             Long userId,
             @PathVariable Long reviewId

--- a/src/main/java/com/uhdyl/backend/token/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/uhdyl/backend/token/repository/RefreshTokenRepository.java
@@ -15,4 +15,6 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
     @Modifying
     @Query("DELETE FROM RefreshToken r WHERE r.expiredAt <= :timeToDelete")
     void deleteAllRefreshToken(LocalDateTime timeToDelete);
+
+    boolean existsByUserId(Long userId);
 }

--- a/src/main/java/com/uhdyl/backend/user/controller/UserController.java
+++ b/src/main/java/com/uhdyl/backend/user/controller/UserController.java
@@ -29,7 +29,7 @@ public class UserController implements UserApi {
 
     @AssignUserId
     @DeleteMapping("/logout")
-    @PreAuthorize(" isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize(" isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<Void>> logout(Long userId){
         userService.logout(userId);
         return ResponseEntity.ok(createSuccessResponse());
@@ -37,7 +37,7 @@ public class UserController implements UserApi {
 
     @AssignUserId
     @PostMapping("/location")
-    @PreAuthorize(" isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize(" isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<Void>> saveLocation(@RequestBody LocationRequest request,
                                                            @Parameter(hidden = true) Long userId){
         userService.saveLocation(userId, request.getLocation_x(), request.getLocation_y());
@@ -49,7 +49,7 @@ public class UserController implements UserApi {
      */
     @AssignUserId
     @PostMapping("/complete-registration")
-    @PreAuthorize(" isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize(" isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<TokenResponse>> completeRegistration(
             Long userId
     ){
@@ -59,7 +59,7 @@ public class UserController implements UserApi {
 
     @AssignUserId
     @PostMapping("/nickname")
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<Void>> updateNickname(
             Long userId,
             @RequestBody UserNicknameUpdateRequest request
@@ -70,14 +70,14 @@ public class UserController implements UserApi {
 
     @AssignUserId
     @GetMapping("/profile")
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<UserProfileResponse>> getProfile(Long userId){
         return ResponseEntity.ok(createSuccessResponse(userService.getProfile(userId)));
     }
 
     @AssignUserId
     @PatchMapping("/profile")
-    @PreAuthorize("isAuthenticated() and hasAuthority('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<Void>> updateProfile(
             Long userId,
             @RequestBody UserProfileUpdateRequest request

--- a/src/main/java/com/uhdyl/backend/user/domain/User.java
+++ b/src/main/java/com/uhdyl/backend/user/domain/User.java
@@ -53,14 +53,23 @@ public class User extends BaseEntity {
     @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<Review> reviews = new ArrayList<>();
 
+    /*
+    권한을 계층적으로 설정했기에(FARMER > USER)
+    구매자/판매자 중 어떤 상태인지 기존의 권한만으로는 표시할 수 없음
+    판매자 -> 구매자 전환 시 권한을 FARMER -> USER로 변환하는 것은 부자연스러움
+    따라서 현재의 권한(구매자/판매자)를 구별할 수 있는 필드 mode를 추가
+     */
+    private String mode;
+
     @Builder
-    public User(String email, UserRole role, String name, String picture, OAuth2Provider provider, String providerId) {
+    public User(String email, UserRole role, String name, String picture, OAuth2Provider provider, String providerId, String mode) {
         this.email = email;
         this.role = role;
         this.name = name;
         this.picture = picture;
         this.provider = provider;
         this.providerId = providerId;
+        this.mode = mode;
     }
 
     public void deleteImage(){
@@ -86,12 +95,13 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public void updateProfile(JsonNullable<String> picture, JsonNullable<String> nickname){
+    public void updateProfile(JsonNullable<String> picture, JsonNullable<String> nickname, String mode){
 
         if(picture.isPresent())
             this.picture = picture.get();
         if(nickname.isPresent())
             this.nickname = nickname.get();
+        this.mode = mode;
     }
 
     public void updateUserToFarmer(){
@@ -102,5 +112,9 @@ public class User extends BaseEntity {
         if(this.location_x == null || this.location_y == null)
             return false;
         return true;
+    }
+
+    public void updateMode(String mode){
+        this.mode = mode;
     }
 }

--- a/src/main/java/com/uhdyl/backend/user/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/com/uhdyl/backend/user/dto/request/UserProfileUpdateRequest.java
@@ -1,10 +1,17 @@
 package com.uhdyl.backend.user.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import org.openapitools.jackson.nullable.JsonNullable;
 
 public record UserProfileUpdateRequest (
+        @Schema(description = "프로필 이미지 url", example = "http://어쩌구저쩌구")
         JsonNullable<String> profileImageUrl,
-        JsonNullable<String> nickname
+
+        @Schema(description = "유저 닉네임", example = "치킨먹는고양이")
+        JsonNullable<String> nickname,
+
+        @Schema(description = "사용자의 현재 모드", example = "구매자|판매자")
+        String mode
 ){
 
 }

--- a/src/main/java/com/uhdyl/backend/user/dto/response/UserProfileResponse.java
+++ b/src/main/java/com/uhdyl/backend/user/dto/response/UserProfileResponse.java
@@ -5,13 +5,15 @@ import com.uhdyl.backend.user.domain.User;
 public record UserProfileResponse(
         String profileImageUrl,
         String nickname,
-        String role
+        String role,
+        String mode
 ) {
     public static UserProfileResponse to(User user){
         return new UserProfileResponse(
                 user.getPicture(),
                 user.getNickname(),
-                user.getRole().name()
+                user.getRole().name(),
+                user.getMode()
         );
     }
 }

--- a/src/main/java/com/uhdyl/backend/user/service/UserService.java
+++ b/src/main/java/com/uhdyl/backend/user/service/UserService.java
@@ -43,10 +43,6 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new BusinessException(ExceptionType.USER_NOT_FOUND));
 
-        if (!isFarmer(userId)){
-            throw new BusinessException(ExceptionType.USER_NOT_FARMER);
-        }
-
         user.updateLocation(locationX, locationY);
         userRepository.save(user);
     }
@@ -65,7 +61,6 @@ public class UserService {
     public UserProfileResponse getProfile(Long userId){
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
-
         return UserProfileResponse.to(user);
     }
 
@@ -75,10 +70,10 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
 
-        if(userRepository.existsByNickname(request.nickname().get()))
+        if(request.nickname().isPresent() && userRepository.existsByNickname(request.nickname().get()))
             throw new BusinessException(ExceptionType.USER_NICKNAME_DUPLICATED);
 
-        user.updateProfile(request.profileImageUrl(), request.nickname());
+        user.updateProfile(request.profileImageUrl(), request.nickname(), request.mode());
     }
 
     @Transactional
@@ -89,6 +84,7 @@ public class UserService {
         if(!user.isBBatRegistered())
             throw new BusinessException(ExceptionType.BBAT_NOT_UPDATED);
 
+        user.updateMode("판매자");
         user.updateUserToFarmer();
         JwtUserClaim claim = new JwtUserClaim(userId, user.getRole());
         return jwtHandler.createTokens(claim);


### PR DESCRIPTION
## What is this PR?🔍
- 디자인에 맞게 user api의 출력 형식을 변경합니다.
- 계층적 권한이 적용되지 않았던 오류를 수정합니다.
- 요청 형식이 모호했던 프로필 수정 api의 요청 형식 example을 추가합니다.
- 
## Changes💻
- 스프링 시큐리티는 내부적으로 권한 체크 시(`@PreAuthorize` 사용 시) 내부적으로 `ROLE_` prefix가 붙은 값을 표준으로 사용합니다.
- 이전 코드에서는 `JwtAuthentication`에서 권한 세팅 시 ROLE_ 이 붙지 않는 값을 넣었고, 계층적 권한 설정 시 `ROLE_FARMER` > `ROLE_USER`로 설정되었기에 JWT에 저장되어있던 `FARMER`는 `ROLE_FARMER`와 매칭되지 않아 정상적인 권한 체크가 되지 않았습니다.
- 이 문제는 JwtAuthentication 권한 세팅 시 ROLE_ 이 붙는 값으로 세팅하고 `@PreAuthorize` 사용 시 `hasAuthority` 대신 `hasRole`를 사용함으로 해결했습니다.
- 사용자의 현재 상태(구매자|판매자)를 나타내는 필드를 user 도메인에 추가했습니다.
- 모호하던 프로필 수정 api 요청 형식을 `@Schema`를 사용하여 분명하게 나타냈습니다.
- 
- 

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 사용자 프로필에 구매자/판매자 상태를 구분하는 'mode' 필드가 추가되었습니다.
  * 프로필 수정 및 조회 시 'mode' 정보가 포함됩니다.

* **버그 수정**
  * 닉네임이 입력되지 않은 경우 중복 확인 과정에서 발생할 수 있는 오류가 방지되었습니다.

* **기능 개선**
  * 위치 저장 기능이 모든 사용자에게 허용됩니다(기존에는 농부에게만 허용).
  * OAuth2(카카오 등)로 회원가입 시 기본 'mode'가 '구매자'로 설정됩니다.
  * 회원가입 완료 시 'mode'가 '판매자'로 변경됩니다.
  * 리프레시 토큰이 사용자별로 1개만 저장되도록 개선되었습니다.

* **보안**
  * 모든 API 접근 권한 체크가 'hasAuthority'에서 'hasRole' 방식으로 일괄 변경되었습니다.

* **문서화**
  * 프로필 수정 요청 필드에 Swagger 예시 및 설명이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->