### PR TITLE
docs: 이미지, 채팅 도메인 문서화

### DIFF
--- a/src/main/java/com/uhdyl/backend/chat/api/ChatMessageApi.java
+++ b/src/main/java/com/uhdyl/backend/chat/api/ChatMessageApi.java
@@ -1,0 +1,91 @@
+package com.uhdyl.backend.chat.api;
+
+import com.uhdyl.backend.chat.dto.request.ChatMessageRequest;
+import com.uhdyl.backend.chat.dto.response.ChatMessageResponse;
+import com.uhdyl.backend.chat.dto.response.ChatRoomResponse;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiFailedResponse;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.jwt.JwtAuthentication;
+import com.uhdyl.backend.global.response.ResponseBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.messaging.handler.annotation.DestinationVariable;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.Payload;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDateTime;
+
+@Tag(name = "채팅 메시지 API", description = "채팅 메시지 관련 API")
+public interface ChatMessageApi {
+    @MessageMapping("/chat/room/{roomId}")
+    public void sendMessage(
+            @DestinationVariable Long roomId,
+            @Payload ChatMessageRequest request,
+            JwtAuthentication authentication
+    );
+
+    @Operation(
+            summary = "채팅 메시지 페이징 조회",
+            description = "채팅 메시지를 페이징 조회합니다. 특정 시간 이전의 채팅 메시지를 불러오려면 특정 시간을 함께 넘겨줘야 합니다." +
+                    "(드래그를 통해 이전 메시지를 불러와야할 경우 가장 예전 메시지의 시간을 함께 전달)"
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ChatMessageResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = ChatMessageResponse.class,
+                    description = "채팅 메시지 페이징 조회 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.CHATROOM_NOT_EXIST),
+                    @SwaggerApiFailedResponse(ExceptionType.WS_ROOM_ACCESS_DENIED)
+
+            }
+    )
+    @GetMapping("/chat/room/{roomId}/messages")
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<Page<ChatMessageResponse>>> findChatMessages(
+            @PathVariable Long roomId,
+            @ParameterObject
+            @PageableDefault(sort = "createdAt", direction = Sort.Direction.DESC, size = 10) Pageable pageable,
+            @RequestParam(required = false) LocalDateTime startDateTime
+    );
+
+
+    @Operation(
+            summary = "WebSocket 채팅 전송",
+            description = """
+                    STOMP SEND /pub/chat/room/{roomId} 로 메시지 전송합니다.
+                    이 엔드포인트는 더미 엔드포인트입니다. 이 엔드포인트를 스웨거에서 테스트할 수 없습니다.
+                    /sub/chat/{roomId}의 경로를 구독하여 메시지를 수신할 수 있습니다.""")
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ChatMessageResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = ChatMessageResponse.class,
+                    description = "채팅 메시지 페이징 조회 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.CHATROOM_NOT_EXIST)
+            }
+    )
+    @PostMapping("/swagger-docs/ws/chat/room/{roomId}")
+    public void swaggerSendMessage(
+            @PathVariable Long roomId,
+            @RequestBody ChatMessageRequest request
+    );
+}

--- a/src/main/java/com/uhdyl/backend/chat/api/ChatRoomApi.java
+++ b/src/main/java/com/uhdyl/backend/chat/api/ChatRoomApi.java
@@ -1,0 +1,48 @@
+package com.uhdyl.backend.chat.api;
+
+import com.uhdyl.backend.chat.dto.request.ChatRoomRequest;
+import com.uhdyl.backend.chat.dto.response.ChatRoomResponse;
+import com.uhdyl.backend.global.aop.AssignUserId;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiFailedResponse;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.ResponseBody;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "채팅방 API", description = "채팅방 관련 API")
+public interface ChatRoomApi {
+    @Operation(
+            summary = "채팅방 생성",
+            description = "구매자는 판매자와의 채팅방을 생성합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ChatRoomResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = ChatRoomResponse.class,
+                    description = "채팅방 생성 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.CANT_CREATE_CHATROOM)
+            }
+    )
+    @PostMapping("/chat/room")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<ChatRoomResponse>> createChatRoom(
+            // TODO: 현재는 상대방의 ID를 전달받지만, 프론트 연결 시에는 상품의 PK 또는 상품의 제목과 닉네임을 받아서 채팅방을 만드는 구조로 변경해야됨
+            @RequestBody ChatRoomRequest request,
+            @Parameter(hidden = true) Long userId
+    );
+}

--- a/src/main/java/com/uhdyl/backend/chat/controller/ChatMessageController.java
+++ b/src/main/java/com/uhdyl/backend/chat/controller/ChatMessageController.java
@@ -1,10 +1,12 @@
 package com.uhdyl.backend.chat.controller;
 
+import com.uhdyl.backend.chat.api.ChatMessageApi;
 import com.uhdyl.backend.chat.dto.request.ChatMessageRequest;
 import com.uhdyl.backend.chat.dto.response.ChatMessageResponse;
 import com.uhdyl.backend.chat.service.ChatMessageService;
 import com.uhdyl.backend.global.jwt.JwtAuthentication;
 import com.uhdyl.backend.global.response.ResponseBody;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -27,7 +29,7 @@ import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessRespon
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-public class ChatMessageController {
+public class ChatMessageController implements ChatMessageApi {
 
     private final ChatMessageService chatMessageService;
     private final SimpMessagingTemplate simpMessagingTemplate;
@@ -52,5 +54,13 @@ public class ChatMessageController {
     ) {
         Page<ChatMessageResponse> response = chatMessageService.findChatMessages(roomId, pageable, startDateTime);
         return ResponseEntity.ok(createSuccessResponse(response));
+    }
+
+    @PostMapping("/chat/room/{roomId}")
+    public void swaggerSendMessage(
+            @PathVariable Long roomId,
+            @RequestBody ChatMessageRequest request
+    ) {
+        // 실제 동작 없음 - Swagger 문서용
     }
 }

--- a/src/main/java/com/uhdyl/backend/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/uhdyl/backend/chat/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.uhdyl.backend.chat.controller;
 
+import com.uhdyl.backend.chat.api.ChatRoomApi;
 import com.uhdyl.backend.chat.dto.request.ChatRoomRequest;
 import com.uhdyl.backend.chat.dto.response.ChatRoomResponse;
 import com.uhdyl.backend.chat.service.ChatRoomService;
@@ -18,7 +19,7 @@ import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessRespon
 @RestController
 @RequiredArgsConstructor
 @Slf4j
-public class ChatRoomController {
+public class ChatRoomController implements ChatRoomApi {
 
     private final ChatRoomService chatRoomService;
 

--- a/src/main/java/com/uhdyl/backend/global/jwt/JwtHandler.java
+++ b/src/main/java/com/uhdyl/backend/global/jwt/JwtHandler.java
@@ -8,6 +8,7 @@ import com.uhdyl.backend.user.domain.UserRole;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jwts;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -33,6 +34,7 @@ public class JwtHandler {
         secretKey = new SecretKeySpec(jwtProperties.getSecretKey().getBytes(StandardCharsets.UTF_8), Jwts.SIG.HS256.key().build().getAlgorithm());
     }
 
+    @Transactional
     public Token createTokens(JwtUserClaim jwtUserClaim) {
         Map<String, Object> tokenClaims = this.createClaims(jwtUserClaim);
         Date now = new Date(System.currentTimeMillis());

--- a/src/main/java/com/uhdyl/backend/image/api/ImageApi.java
+++ b/src/main/java/com/uhdyl/backend/image/api/ImageApi.java
@@ -1,0 +1,151 @@
+package com.uhdyl.backend.image.api;
+
+import com.uhdyl.backend.global.aop.AssignUserId;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiFailedResponse;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.image.dto.request.ChatImageUploadRequest;
+import com.uhdyl.backend.image.dto.request.ImageDeleteRequest;
+import com.uhdyl.backend.image.dto.request.ProductImageUploadRequest;
+import com.uhdyl.backend.image.dto.request.ProfileImageUploadRequest;
+import com.uhdyl.backend.image.dto.response.ImageSavedSuccessResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Tag(name = "이미지 API", description = "이미지 관련 API")
+public interface ImageApi {
+
+    @Operation(
+            summary = "프로필 이미지 업로드",
+            description = "프로필 이미지를 업로드할 수 있습니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(implementation = ProfileImageUploadRequest.class)
+                    )
+            )
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ImageSavedSuccessResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = ImageSavedSuccessResponse.class,
+                    description = "프로필 이미지 업로드 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.IMAGE_SIZE_EXCEEDED),
+                    @SwaggerApiFailedResponse(ExceptionType.INVALID_IMAGE_FILE),
+                    @SwaggerApiFailedResponse(ExceptionType.IMAGE_UPLOAD_FAILED)
+            }
+    )
+    @PostMapping(value = "/image/user", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<ImageSavedSuccessResponse>> uploadProfileImage(
+            @Parameter(hidden = true) Long userId,
+            @RequestParam MultipartFile image
+    );
+
+    @Operation(
+            summary = "채팅 이미지 업로드",
+            description = "채팅 이미지를 업로드할 수 있습니다.",
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(implementation = ChatImageUploadRequest.class)
+                    )
+            )
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ImageSavedSuccessResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = ImageSavedSuccessResponse.class,
+                    description = "채팅 이미지 업로드 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.IMAGE_SIZE_EXCEEDED),
+                    @SwaggerApiFailedResponse(ExceptionType.INVALID_IMAGE_FILE),
+                    @SwaggerApiFailedResponse(ExceptionType.IMAGE_UPLOAD_FAILED)
+            }
+    )
+    @PostMapping(value="/image/chat", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<ImageSavedSuccessResponse>> uploadChatMessageImage(
+            @RequestParam Long roomId,
+            @RequestParam MultipartFile image
+    );
+
+
+    @Operation(
+            summary = "상품 이미지 업로드",
+            description = "상품 이미지를 업로드할 수 있습니다.",
+
+            requestBody = @io.swagger.v3.oas.annotations.parameters.RequestBody(
+                    content = @Content(
+                            mediaType = MediaType.MULTIPART_FORM_DATA_VALUE,
+                            schema = @Schema(implementation = ProductImageUploadRequest.class)
+                    )
+            )
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ImageSavedSuccessResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = ImageSavedSuccessResponse.class,
+                    description = "상품 이미지 업로드 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.IMAGE_SIZE_EXCEEDED),
+                    @SwaggerApiFailedResponse(ExceptionType.INVALID_IMAGE_FILE),
+                    @SwaggerApiFailedResponse(ExceptionType.IMAGE_UPLOAD_FAILED)
+            }
+    )
+    @PostMapping(value="/image/product", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<List<ImageSavedSuccessResponse>>> uploadProductImage(
+            @Parameter(content = @Content(mediaType = MediaType.MULTIPART_FORM_DATA_VALUE))
+            @RequestParam("images") List<MultipartFile> images
+    );
+
+
+    @Operation(
+            summary = "이미지 삭제",
+            description = "이전에 업로드한 이미지를 삭제할 수 있습니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ImageSavedSuccessResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "이미지 삭제 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.IMAGE_ACCESS_DENIED),
+                    @SwaggerApiFailedResponse(ExceptionType.IMAGE_DELETE_FAILED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND)
+            }
+    )
+    @DeleteMapping("/image")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<Void>> deleteImage(
+            @RequestBody List<ImageDeleteRequest> request,
+            @Parameter(hidden = true) Long userId
+    );
+}

--- a/src/main/java/com/uhdyl/backend/image/controller/ImageController.java
+++ b/src/main/java/com/uhdyl/backend/image/controller/ImageController.java
@@ -2,6 +2,7 @@ package com.uhdyl.backend.image.controller;
 
 import com.uhdyl.backend.global.aop.AssignUserId;
 import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.image.api.ImageApi;
 import com.uhdyl.backend.image.dto.request.ImageDeleteRequest;
 import com.uhdyl.backend.image.dto.response.ImageSavedSuccessResponse;
 import com.uhdyl.backend.image.service.ImageService;
@@ -18,7 +19,7 @@ import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessRespon
 
 @RestController
 @RequiredArgsConstructor
-public class ImageController {
+public class ImageController implements ImageApi {
 
     private final ImageService imageService;
 

--- a/src/main/java/com/uhdyl/backend/image/dto/request/ChatImageUploadRequest.java
+++ b/src/main/java/com/uhdyl/backend/image/dto/request/ChatImageUploadRequest.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.image.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ChatImageUploadRequest(
+        @Schema(type = "string", format = "binary", description = "채팅 이미지 파일")
+        MultipartFile image
+) {
+}

--- a/src/main/java/com/uhdyl/backend/image/dto/request/ProductImageUploadRequest.java
+++ b/src/main/java/com/uhdyl/backend/image/dto/request/ProductImageUploadRequest.java
@@ -1,0 +1,16 @@
+package com.uhdyl.backend.image.dto.request;
+
+import io.swagger.v3.oas.annotations.media.ArraySchema;
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+public record ProductImageUploadRequest(
+        @ArraySchema(
+                schema = @Schema(format = "binary"),
+                arraySchema = @Schema(description = "상품 이미지들")
+        )
+        List<MultipartFile> images
+) {
+}

--- a/src/main/java/com/uhdyl/backend/image/dto/request/ProfileImageUploadRequest.java
+++ b/src/main/java/com/uhdyl/backend/image/dto/request/ProfileImageUploadRequest.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.image.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.web.multipart.MultipartFile;
+
+public record ProfileImageUploadRequest(
+        @Schema(type = "string", format = "binary", description = "프로필 이미지 파일")
+        MultipartFile image
+) {
+}


### PR DESCRIPTION
## What is this PR?🔍
- 이미지와 채팅 도메인의 문서화를 진행합니다.
- 
## Changes💻
- `JwtHandler`의 `createToken` 메서드에 `@Transactional`을 추가합니다.
- `MultiPartFile`을 스웨거에 표현하기 위해 전용 DTO를 추가합니다. 이 DTO는 실제 컨트롤러에서는 사용되지 않고 스웨거 문서화를 위해 사용됩니다.
- HTTP 메서드가 아닌 메시지 전송 API를 스웨거 문서에 표현하기 위해 더미 메서드`swaggerSendMessage`를 만들었습니다.
- `image` 도메인의 상품 이미지 업로드의 경우 스웨거 문서에서 `MultiPartFile`이 제대로 표현되지 않는 버그가 있습니다. 프론트에게 API 호출 방법을 따로 전달하고, 버그를 추후에 해결하도록 하겠습니다.

## ScreenShot📷
