### PR TITLE
feat: 찜 도메인 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
+++ b/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
@@ -60,7 +60,12 @@ public enum ExceptionType {
     INVALID_INPUT(BAD_REQUEST, "P001", "입력 값이 올바르지 않습니다."),
     AI_GENERATION_FAILED(INTERNAL_SERVER_ERROR, "P002", "AI 생성에 실패했습니다."),
     PRODUCT_NOT_FOUND(NOT_FOUND, "P003", "상품이 존재하지 않습니다."),
-    CANT_DELETE_PRODUCT(FORBIDDEN, "P004", "다른 사용자의 상품을 삭제할 수 없습니다.")
+    CANT_DELETE_PRODUCT(FORBIDDEN, "P004", "다른 사용자의 상품을 삭제할 수 없습니다."),
+
+    // Zzim
+    ALREADY_ZZIMED(FORBIDDEN, "Z001", "이미 찜한 상품입니다."),
+    ZZIM_NOT_FOUND(NOT_FOUND, "Z002","존재하지 않는 찜입니다."),
+    ZZIM_ACCESS_DENIED(FORBIDDEN, "Z003","해당 찜에 접근할 수 없습니다"),
 
     ;
 

--- a/src/main/java/com/uhdyl/backend/zzim/api/ZzimApi.java
+++ b/src/main/java/com/uhdyl/backend/zzim/api/ZzimApi.java
@@ -1,0 +1,99 @@
+package com.uhdyl.backend.zzim.api;
+
+import com.uhdyl.backend.global.aop.AssignUserId;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiFailedResponse;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
+import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
+import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.zzim.dto.request.ZzimCreateRequest;
+import com.uhdyl.backend.zzim.dto.response.ZzimResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Tag(name = "찜 API", description = "찜 관련 API")
+public interface ZzimApi {
+
+    @Operation(
+            summary = "찜 등록",
+            description = "사용자는 판매 글을 찜으로 등록합니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "찜 등록 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.ALREADY_ZZIMED),
+                    @SwaggerApiFailedResponse(ExceptionType.PRODUCT_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.ALREADY_ZZIMED)
+            }
+    )
+    @PostMapping("/zzim")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<Void>> createZzim(
+            @Parameter(hidden = true) Long userId,
+            @RequestBody ZzimCreateRequest request
+    );
+
+    @Operation(
+            summary = "찜 페이징 조회",
+            description = "등록한 찜을 페이징으로 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ZzimResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    responsePage = ZzimResponse.class,
+                    description = "리뷰 페이징 조회 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+            }
+    )
+    @GetMapping("/zzim")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<GlobalPageResponse<ZzimResponse>>> getZzims(
+            @Parameter(hidden = true) Long userId,
+            @ParameterObject
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    );
+
+    @Operation(
+            summary = "찜 삭제",
+            description = "사용자는 자신이 등록한 찜을 삭제할 수 있습니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    description = "리뷰 삭제 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.ZZIM_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.ZZIM_ACCESS_DENIED)
+            }
+    )
+    @DeleteMapping("/zzim/{zzimId}")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<Void>> deleteZzim(
+            @Parameter(hidden = true) Long userId,
+            @PathVariable Long zzimId
+    );
+}

--- a/src/main/java/com/uhdyl/backend/zzim/api/ZzimApi.java
+++ b/src/main/java/com/uhdyl/backend/zzim/api/ZzimApi.java
@@ -58,7 +58,7 @@ public interface ZzimApi {
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
                     responsePage = ZzimResponse.class,
-                    description = "리뷰 페이징 조회 성공"
+                    description = "찜 페이징 조회 성공"
             ),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
@@ -80,7 +80,7 @@ public interface ZzimApi {
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
-                    description = "리뷰 삭제 성공"
+                    description = "찜 삭제 성공"
             ),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),

--- a/src/main/java/com/uhdyl/backend/zzim/controller/ZzimController.java
+++ b/src/main/java/com/uhdyl/backend/zzim/controller/ZzimController.java
@@ -1,0 +1,56 @@
+package com.uhdyl.backend.zzim.controller;
+
+import com.uhdyl.backend.global.aop.AssignUserId;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
+import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.zzim.api.ZzimApi;
+import com.uhdyl.backend.zzim.dto.request.ZzimCreateRequest;
+import com.uhdyl.backend.zzim.dto.response.ZzimResponse;
+import com.uhdyl.backend.zzim.service.ZzimService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessResponse;
+
+@RestController
+@RequiredArgsConstructor
+public class ZzimController implements ZzimApi {
+    private final ZzimService zzimService;
+
+    @PostMapping("/zzim")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<Void>> createZzim(
+            Long userId,
+            @RequestBody ZzimCreateRequest request
+            ) {
+        zzimService.createZzim(userId, request.productId());
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    @GetMapping("/zzim")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<GlobalPageResponse<ZzimResponse>>> getZzims(
+            Long userId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ){
+        return ResponseEntity.ok(createSuccessResponse(zzimService.getZzims(userId, pageable)));
+    }
+
+    @DeleteMapping("/zzim/{zzimId}")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<Void>> deleteZzim(
+            Long userId,
+            @PathVariable Long zzimId
+    ){
+        zzimService.deleteZzim(userId, zzimId);
+        return ResponseEntity.ok(createSuccessResponse());
+    }
+}

--- a/src/main/java/com/uhdyl/backend/zzim/domain/Zzim.java
+++ b/src/main/java/com/uhdyl/backend/zzim/domain/Zzim.java
@@ -11,17 +11,27 @@ import lombok.NoArgsConstructor;
 @Entity
 @Getter
 @NoArgsConstructor
+@Table(
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_zzim_user_product",
+                columnNames = {"user_id", "product_id"}
+        ),
+        indexes = {
+                @Index(name = "idx_zzim_user", columnList = "user_id"),
+                @Index(name = "idx_zzim_product", columnList = "product_id")
+        }
+)
 public class Zzim extends BaseEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "product_id")
+    @JoinColumn(name = "product_id", nullable = false)
     private Product product;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @Builder

--- a/src/main/java/com/uhdyl/backend/zzim/domain/Zzim.java
+++ b/src/main/java/com/uhdyl/backend/zzim/domain/Zzim.java
@@ -1,0 +1,32 @@
+package com.uhdyl.backend.zzim.domain;
+
+import com.uhdyl.backend.global.base.BaseEntity;
+import com.uhdyl.backend.product.domain.Product;
+import com.uhdyl.backend.user.domain.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class Zzim extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @Builder
+    public Zzim(Product product, User user) {
+        this.product = product;
+        this.user = user;
+    }
+}

--- a/src/main/java/com/uhdyl/backend/zzim/dto/request/ZzimCreateRequest.java
+++ b/src/main/java/com/uhdyl/backend/zzim/dto/request/ZzimCreateRequest.java
@@ -1,0 +1,6 @@
+package com.uhdyl.backend.zzim.dto.request;
+
+public record ZzimCreateRequest(
+        Long productId
+) {
+}

--- a/src/main/java/com/uhdyl/backend/zzim/dto/response/ZzimResponse.java
+++ b/src/main/java/com/uhdyl/backend/zzim/dto/response/ZzimResponse.java
@@ -1,0 +1,9 @@
+package com.uhdyl.backend.zzim.dto.response;
+
+public record ZzimResponse(
+        Long id,
+        String title,
+        String imageUrl,
+        String price,
+        String sellerName
+) {}

--- a/src/main/java/com/uhdyl/backend/zzim/repository/CustomZzimRepository.java
+++ b/src/main/java/com/uhdyl/backend/zzim/repository/CustomZzimRepository.java
@@ -1,0 +1,9 @@
+package com.uhdyl.backend.zzim.repository;
+
+import com.uhdyl.backend.global.response.GlobalPageResponse;
+import com.uhdyl.backend.zzim.dto.response.ZzimResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomZzimRepository {
+    GlobalPageResponse<ZzimResponse> findByUser(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/uhdyl/backend/zzim/repository/CustomZzimRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/zzim/repository/CustomZzimRepositoryImpl.java
@@ -44,7 +44,7 @@ public class CustomZzimRepositoryImpl implements CustomZzimRepository{
                 .innerJoin(qZzim.product, qProduct)
                 .leftJoin(qProduct.images, qImage)
                 .where(builder)
-                .groupBy(qZzim.id, qProduct.title, qProduct.price, qProduct.name)
+                .groupBy(qZzim.id, qProduct.title, qProduct.price, qProduct.user.name)
                 .orderBy(qZzim.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/uhdyl/backend/zzim/repository/CustomZzimRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/zzim/repository/CustomZzimRepositoryImpl.java
@@ -1,0 +1,63 @@
+package com.uhdyl.backend.zzim.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
+import com.uhdyl.backend.image.domain.QImage;
+import com.uhdyl.backend.product.domain.QProduct;
+import com.uhdyl.backend.zzim.domain.QZzim;
+import com.uhdyl.backend.zzim.dto.response.ZzimResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomZzimRepositoryImpl implements CustomZzimRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public GlobalPageResponse<ZzimResponse> findByUser(Long userId, Pageable pageable) {
+        QZzim qZzim = QZzim.zzim;
+        QProduct qProduct = QProduct.product;
+        QImage qImage = QImage.image;
+        BooleanBuilder builder = new BooleanBuilder();
+
+        builder.and(qZzim.user.id.eq(userId));
+
+        List<ZzimResponse> queryResponse = jpaQueryFactory
+                .select(
+                        Projections.constructor(
+                                ZzimResponse.class,
+                                qZzim.id,
+                                qProduct.title,
+                                qImage.imageUrl.min(),
+                                qProduct.price,
+                                qProduct.user.name
+                        )
+                )
+                .from(qZzim)
+                .innerJoin(qZzim.product, qProduct)
+                .leftJoin(qProduct.images, qImage)
+                .where(builder)
+                .groupBy(qZzim.id, qProduct.title, qProduct.price, qProduct.name)
+                .orderBy(qZzim.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = jpaQueryFactory
+                .select(qZzim.count())
+                .from(qZzim)
+                .where(builder)
+                .fetchOne();
+
+
+        Page<ZzimResponse> pageResponse =  new PageImpl<>(queryResponse, pageable, total != null ? total : 0);
+        return GlobalPageResponse.create(pageResponse);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/zzim/repository/ZzimRepository.java
+++ b/src/main/java/com/uhdyl/backend/zzim/repository/ZzimRepository.java
@@ -1,0 +1,8 @@
+package com.uhdyl.backend.zzim.repository;
+
+import com.uhdyl.backend.zzim.domain.Zzim;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ZzimRepository extends JpaRepository<Zzim, Long>, CustomZzimRepository {
+    boolean existsByUser_IdAndProduct_Id(Long userId, Long productId);
+}

--- a/src/main/java/com/uhdyl/backend/zzim/service/ZzimService.java
+++ b/src/main/java/com/uhdyl/backend/zzim/service/ZzimService.java
@@ -1,0 +1,67 @@
+package com.uhdyl.backend.zzim.service;
+
+import com.uhdyl.backend.global.exception.BusinessException;
+import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
+import com.uhdyl.backend.product.domain.Product;
+import com.uhdyl.backend.product.repository.ProductRepository;
+import com.uhdyl.backend.user.domain.User;
+import com.uhdyl.backend.user.repository.UserRepository;
+import com.uhdyl.backend.zzim.domain.Zzim;
+import com.uhdyl.backend.zzim.dto.response.ZzimResponse;
+import com.uhdyl.backend.zzim.repository.ZzimRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ZzimService {
+
+    private final ZzimRepository zzimRepository;
+    private final UserRepository userRepository;
+    private final ProductRepository productRepository;
+
+    @Transactional
+    public void createZzim(Long userId, Long productId){
+
+        if(!userRepository.existsById(userId))
+            throw new BusinessException(ExceptionType.USER_NOT_FOUND);
+        User userProxy = userRepository.getReferenceById(userId);
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(()-> new BusinessException(ExceptionType.PRODUCT_NOT_FOUND));
+
+        if(zzimRepository.existsByUser_IdAndProduct_Id(userId, productId))
+            throw new BusinessException(ExceptionType.ALREADY_ZZIMED);
+
+        Zzim zzim = Zzim.builder()
+                .user(userProxy)
+                .product(product)
+                .build();
+        zzimRepository.save(zzim);
+    }
+
+    public GlobalPageResponse<ZzimResponse> getZzims(Long userId, Pageable pageable){
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new BusinessException(ExceptionType.USER_NOT_FOUND));
+
+        return zzimRepository.findByUser(userId, pageable);
+    }
+
+    @Transactional
+    public void deleteZzim(Long userId, Long zzimId){
+        if(!userRepository.existsById(userId))
+            throw new BusinessException(ExceptionType.USER_NOT_FOUND);
+
+        Zzim zzim = zzimRepository.findById(zzimId)
+                .orElseThrow(()-> new BusinessException(ExceptionType.ZZIM_NOT_FOUND));
+        if(!zzim.getUser().getId().equals(userId))
+            throw new BusinessException(ExceptionType.ZZIM_ACCESS_DENIED);
+
+        zzimRepository.deleteById(zzimId);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/zzim/service/ZzimService.java
+++ b/src/main/java/com/uhdyl/backend/zzim/service/ZzimService.java
@@ -42,7 +42,12 @@ public class ZzimService {
                 .user(userProxy)
                 .product(product)
                 .build();
-        zzimRepository.save(zzim);
+        try {
+            zzimRepository.save(zzim);
+        }
+        catch (Exception e){
+            throw new BusinessException(ExceptionType.ALREADY_ZZIMED);
+        }
     }
 
     public GlobalPageResponse<ZzimResponse> getZzims(Long userId, Pageable pageable){

--- a/src/main/java/com/uhdyl/backend/zzim/service/ZzimService.java
+++ b/src/main/java/com/uhdyl/backend/zzim/service/ZzimService.java
@@ -35,9 +35,6 @@ public class ZzimService {
         Product product = productRepository.findById(productId)
                 .orElseThrow(()-> new BusinessException(ExceptionType.PRODUCT_NOT_FOUND));
 
-        if(zzimRepository.existsByUser_IdAndProduct_Id(userId, productId))
-            throw new BusinessException(ExceptionType.ALREADY_ZZIMED);
-
         Zzim zzim = Zzim.builder()
                 .user(userProxy)
                 .product(product)


### PR DESCRIPTION
## What is this PR?🔍
- 찜 도메인을 추가합니다.
- 찜 등록, 조회, 삭제 API를 추가합니다.
- 스웨거 문서화를 추가합니다.
## Changes💻
- QueryDSL을 사용해 사용자가 찜으로 등록한 판매 게시글의 정보를 불러옵니다.
-
-

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 찜 기능 추가: 찜 등록, 내 찜 목록 조회(페이지네이션·최신순), 찜 삭제 지원
  - 목록 항목에 상품 제목/이미지/가격/판매자 정보 포함

- **Bug Fixes**
  - 중복 찜 방지, 존재하지 않는 찜/상품 및 접근 권한 오류 처리 강화
  - 찜 관련 오류 코드 및 메시지 추가 (ALREADY_ZZIMED, ZZIM_NOT_FOUND, ZZIM_ACCESS_DENIED)

- **Security**
  - 인증된 사용자(ROLE_USER) 전용으로 제한, 본인 소유 항목만 삭제 가능

- **Documentation**
  - API 문서에 찜 엔드포인트, 요청/응답 스키마, 오류 케이스 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->