### PR TITLE
chore: 채팅방 관련 로직 수정 및 채팅방 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/chat/api/ChatRoomApi.java
+++ b/src/main/java/com/uhdyl/backend/chat/api/ChatRoomApi.java
@@ -58,10 +58,10 @@ public interface ChatRoomApi {
             summary = "채팅방 페이징 조회",
             description = "채팅방 목록을 페이징으로 조회합니다."
     )
-    @ApiResponse(content = @Content(schema = @Schema(implementation = ZzimResponse.class)))
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ChatRoomResponse.class)))
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
-                    responsePage = ZzimResponse.class,
+                    responsePage = ChatRoomResponse.class,
                     description = "채팅방 페이징 조회 성공"
             ),
             errors = {

--- a/src/main/java/com/uhdyl/backend/chat/api/ChatRoomApi.java
+++ b/src/main/java/com/uhdyl/backend/chat/api/ChatRoomApi.java
@@ -7,15 +7,22 @@ import com.uhdyl.backend.global.config.swagger.SwaggerApiFailedResponse;
 import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
 import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
 import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.zzim.dto.response.ZzimResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springdoc.core.annotations.ParameterObject;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -44,5 +51,30 @@ public interface ChatRoomApi {
             // TODO: 현재는 상대방의 ID를 전달받지만, 프론트 연결 시에는 상품의 PK 또는 상품의 제목과 닉네임을 받아서 채팅방을 만드는 구조로 변경해야됨
             @RequestBody ChatRoomRequest request,
             @Parameter(hidden = true) Long userId
+    );
+
+
+    @Operation(
+            summary = "채팅방 페이징 조회",
+            description = "채팅방 목록을 페이징으로 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ZzimResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    responsePage = ZzimResponse.class,
+                    description = "채팅방 페이징 조회 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+            }
+    )
+    @GetMapping("/chat/room")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<GlobalPageResponse<ChatRoomResponse>>> getChatRooms(
+            @Parameter(hidden = true) Long userId,
+            @ParameterObject
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     );
 }

--- a/src/main/java/com/uhdyl/backend/chat/controller/ChatRoomController.java
+++ b/src/main/java/com/uhdyl/backend/chat/controller/ChatRoomController.java
@@ -5,11 +5,16 @@ import com.uhdyl.backend.chat.dto.request.ChatRoomRequest;
 import com.uhdyl.backend.chat.dto.response.ChatRoomResponse;
 import com.uhdyl.backend.chat.service.ChatRoomService;
 import com.uhdyl.backend.global.aop.AssignUserId;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.global.response.ResponseBody;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -27,10 +32,19 @@ public class ChatRoomController implements ChatRoomApi {
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasRole('USER')")
     public ResponseEntity<ResponseBody<ChatRoomResponse>> createChatRoom(
-            // TODO: 현재는 상대방의 ID를 전달받지만, 프론트 연결 시에는 상품의 PK 또는 상품의 제목과 닉네임을 받아서 채팅방을 만드는 구조로 변경해야됨
             @RequestBody ChatRoomRequest request,
             Long userId
     ){
-        return ResponseEntity.ok(createSuccessResponse(chatRoomService.createChatRoom(request.opponentId(), userId)));
+        return ResponseEntity.ok(createSuccessResponse(chatRoomService.createChatRoom(request, userId)));
+    }
+
+    @GetMapping("/chat/room")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<GlobalPageResponse<ChatRoomResponse>>> getChatRooms(
+            Long userId,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    ){
+        return ResponseEntity.ok(createSuccessResponse(chatRoomService.getChatRooms(userId, pageable)));
     }
 }

--- a/src/main/java/com/uhdyl/backend/chat/domain/ChatRoom.java
+++ b/src/main/java/com/uhdyl/backend/chat/domain/ChatRoom.java
@@ -22,12 +22,15 @@ public class ChatRoom extends BaseEntity {
 
     private Long user2;
 
-    private String name;
+    private String chatRoomTitle;
+
+    private Long productId;
 
     @Builder
-    public ChatRoom(Long user1, Long user2, String name) {
+    public ChatRoom(Long user1, Long user2, String chatRoomTitle, Long productId) {
         this.user1 = user1;
         this.user2 = user2;
-        this.name = name;
+        this.chatRoomTitle = chatRoomTitle;
+        this.productId = productId;
     }
 }

--- a/src/main/java/com/uhdyl/backend/chat/dto/request/ChatRoomRequest.java
+++ b/src/main/java/com/uhdyl/backend/chat/dto/request/ChatRoomRequest.java
@@ -1,7 +1,6 @@
 package com.uhdyl.backend.chat.dto.request;
 
 public record ChatRoomRequest (
-        String nickName,
         Long productId
 ){
 }

--- a/src/main/java/com/uhdyl/backend/chat/dto/request/ChatRoomRequest.java
+++ b/src/main/java/com/uhdyl/backend/chat/dto/request/ChatRoomRequest.java
@@ -1,6 +1,7 @@
 package com.uhdyl.backend.chat.dto.request;
 
 public record ChatRoomRequest (
-        Long opponentId
+        String nickName,
+        Long productId
 ){
 }

--- a/src/main/java/com/uhdyl/backend/chat/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/uhdyl/backend/chat/dto/response/ChatRoomResponse.java
@@ -2,21 +2,26 @@ package com.uhdyl.backend.chat.dto.response;
 
 import com.uhdyl.backend.chat.domain.ChatMessage;
 import com.uhdyl.backend.chat.domain.ChatRoom;
+import com.uhdyl.backend.product.domain.Product;
+import com.uhdyl.backend.product.dto.response.ProductListResponse;
 
-import java.util.List;
+import java.time.LocalDateTime;
+
 
 public record ChatRoomResponse(
         Long chatRoomId,
-        Long userId,
-        Long sellerId,
-        String name
+        String chatRoomName,
+        ProductListResponse product,
+        String message,
+        LocalDateTime timestamp
 ) {
-    public static ChatRoomResponse to(ChatRoom chatRoom) {
+    public static ChatRoomResponse to(ChatRoom chatRoom, Product product, ChatMessage chatMessage) {
         return new ChatRoomResponse(
                 chatRoom.getId(),
-                chatRoom.getUser1(),
-                chatRoom.getUser2(),
-                chatRoom.getName()
+                chatRoom.getChatRoomTitle(),
+                ProductListResponse.to(product),
+                chatMessage == null ? "" : chatMessage.getMessage(),
+                chatMessage == null ? chatRoom.getCreatedAt() : chatMessage.getCreatedAt()
         );
     }
 

--- a/src/main/java/com/uhdyl/backend/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/ChatMessageRepository.java
@@ -5,9 +5,12 @@ import com.uhdyl.backend.chat.domain.ChatRoom;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>, CustomChatMessageRepository{
     List<ChatMessage> findMessagesWithUserByChatRoom(ChatRoom chatRoom);
 
     ChatMessage findByPublicId(String publicId);
+
+    Optional<ChatMessage> findFirstByChatRoom_IdOrderByCreatedAtDescIdDesc(Long chatRoomId);
 }

--- a/src/main/java/com/uhdyl/backend/chat/repository/ChatRoomRepository.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/ChatRoomRepository.java
@@ -5,8 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
-public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-    Optional<ChatRoom> findByUser1AndUser2(Long user1, Long user2);
+public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long>, CustomChatRoomRepository {
+    Optional<ChatRoom> findByUser1AndUser2AndProductId(Long user1, Long user2, Long productId);
 
-    ChatRoom findByName(String name);
 }

--- a/src/main/java/com/uhdyl/backend/chat/repository/CustomChatRoomRepository.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/CustomChatRoomRepository.java
@@ -1,0 +1,9 @@
+package com.uhdyl.backend.chat.repository;
+
+import com.uhdyl.backend.chat.dto.response.ChatRoomResponse;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
+import org.springframework.data.domain.Pageable;
+
+public interface CustomChatRoomRepository {
+    GlobalPageResponse<ChatRoomResponse> getChatRooms(Long userId, Pageable pageable);
+}

--- a/src/main/java/com/uhdyl/backend/chat/repository/CustomChatRoomRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/CustomChatRoomRepositoryImpl.java
@@ -1,0 +1,87 @@
+package com.uhdyl.backend.chat.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Expression;
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.uhdyl.backend.chat.domain.ChatRoom;
+import com.uhdyl.backend.chat.domain.QChatMessage;
+import com.uhdyl.backend.chat.domain.QChatRoom;
+import com.uhdyl.backend.chat.dto.response.ChatRoomResponse;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
+import com.uhdyl.backend.image.domain.QImage;
+import com.uhdyl.backend.product.domain.QProduct;
+import com.uhdyl.backend.product.dto.response.ProductListResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class CustomChatRoomRepositoryImpl implements CustomChatRoomRepository{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public GlobalPageResponse<ChatRoomResponse> getChatRooms(Long userId, Pageable pageable) {
+        QChatRoom qChatRoom = QChatRoom.chatRoom;
+        QProduct qProduct = QProduct.product;
+        QImage qImage = QImage.image;
+        QChatMessage qChatMessage = QChatMessage.chatMessage;
+        QChatMessage cm = new QChatMessage("cm");
+
+        BooleanBuilder builder = new BooleanBuilder()
+                .and(qChatRoom.user1.eq(userId).or(qChatRoom.user2.eq(userId)));
+
+        Expression<String> mainImageUrl = JPAExpressions
+                .select(qImage.imageUrl.min())
+                .from(qImage)
+                .where(qImage.in(qProduct.images));
+
+        var latestMsgId = JPAExpressions
+                .select(cm.id.max())
+                .from(cm)
+                .where(cm.chatRoom.id.eq(qChatRoom.id));
+
+        List<ChatRoomResponse> response = jpaQueryFactory
+                .select(Projections.constructor(
+                        ChatRoomResponse.class,
+                        qChatRoom.id,
+                        qChatRoom.chatRoomTitle,
+                        Projections.constructor(
+                                ProductListResponse.class,
+                                qProduct.id,
+                                qProduct.name,
+                                qProduct.price,
+                                qProduct.user.name,
+                                mainImageUrl,
+                                qProduct.isSale
+                        ),
+                        qChatMessage.message,
+                        qChatMessage.createdAt
+                ))
+                .from(qChatRoom)
+                .leftJoin(qProduct).on(qProduct.id.eq(qChatRoom.productId))
+                .leftJoin(qChatMessage).on(
+                        qChatRoom.id.eq(qChatMessage.chatRoom.id)
+                                .and(qChatMessage.id.eq(latestMsgId))
+                )
+                .where(builder)
+                .orderBy(qChatRoom.createdAt.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetch();
+
+        Long total = jpaQueryFactory
+                .select(qChatRoom.count())
+                .from(qChatRoom)
+                .where(builder)
+                .fetchOne();
+
+        return GlobalPageResponse.create(new PageImpl<>(response, pageable, total == null ? 0 : total));
+    }
+
+}

--- a/src/main/java/com/uhdyl/backend/product/dto/response/ProductListResponse.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/response/ProductListResponse.java
@@ -1,6 +1,7 @@
 package com.uhdyl.backend.product.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
+import com.uhdyl.backend.product.domain.Product;
 
 public record ProductListResponse(
         Long id,
@@ -18,5 +19,16 @@ public record ProductListResponse(
         this.sellerName = sellerName;
         this.mainImageUrl = mainImageUrl;
         this.isCompleted = isCompleted;
+    }
+
+    public static ProductListResponse to(Product product){
+        return new ProductListResponse(
+                product.getId(),
+                product.getName(),
+                product.getPrice(),
+                product.getUser().getNickname(),
+                product.getImages().get(0).getImageUrl(),
+                product.isSale()
+        );
     }
 }


### PR DESCRIPTION
## What is this PR?🔍
- 채팅방 생성과 중복 확인 로직을 수정하고 채팅방 목록 조회 API를 추가합니다.
- 
## Changes💻 
- 채팅방 생성 시 상대 유저의 PK를 전달받는 방식에서 채팅방을 만드려는 상품의 PK를 전달받는 방식으로 변경합니다.
- 채팅방과 상품의 연관관계를 추가하여 각 상품 게시글 별로 채팅방을 생성 가능하도록 합니다.
- 채팅방 중복 확인 시 유저의 PK와 상품의 PK를 함께 검사합니다.
- 채팅방 목록 조회 API를 추가합니다.
- 채팅방의 제목은 상품 게시글의 제목으로 설정했습니다.
-
-

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 내 채팅방 목록 조회 API 추가: 페이지네이션(기본 10개, 최신순)으로 내 채팅방을 조회할 수 있습니다.
  - 채팅방 응답 확장: 채팅방 제목, 연관 상품 정보, 마지막 메시지 내용 및 타임스탬프 포함.

- Refactor
  - 채팅방 생성 흐름을 상품 중심으로 개편(요청 필드 opponentId → productId로 변경).
  - 기존 동일 사용자/상품 재사용 로직 및 마지막 메시지 포함 반환 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->