### PR TITLE
chore: zzim 추가, 삭제 API 변경

### DIFF
--- a/src/main/java/com/uhdyl/backend/zzim/api/ZzimApi.java
+++ b/src/main/java/com/uhdyl/backend/zzim/api/ZzimApi.java
@@ -7,8 +7,9 @@ import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
 import com.uhdyl.backend.global.exception.ExceptionType;
 import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.global.response.ResponseBody;
-import com.uhdyl.backend.zzim.dto.request.ZzimCreateRequest;
+import com.uhdyl.backend.zzim.dto.request.ZzimToggleRequest;
 import com.uhdyl.backend.zzim.dto.response.ZzimResponse;
+import com.uhdyl.backend.zzim.dto.response.ZzimToggleResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -23,12 +24,15 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
+import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessResponse;
+
 @Tag(name = "찜 API", description = "찜 관련 API")
 public interface ZzimApi {
 
     @Operation(
-            summary = "찜 등록",
-            description = "사용자는 판매 글을 찜으로 등록합니다."
+            summary = "찜 토글",
+            description = "사용자는 판매 글이 찜으로 등록되어 있으면 삭제합니다. " +
+                    "사용자는 판매 글이 찜으로 등록되어 있지 않으면 찜으로 등록합니다."
     )
     @SwaggerApiResponses(
             success = @SwaggerApiSuccessResponse(
@@ -45,14 +49,15 @@ public interface ZzimApi {
     @PostMapping("/zzim")
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasRole('USER')")
-    public ResponseEntity<ResponseBody<Void>> createZzim(
+    public ResponseEntity<ResponseBody<ZzimToggleResponse>> toggleZzim(
             @Parameter(hidden = true) Long userId,
-            @RequestBody ZzimCreateRequest request
+            @RequestBody ZzimToggleRequest request
     );
 
     @Operation(
             summary = "찜 페이징 조회",
-            description = "등록한 찜을 페이징으로 조회합니다."
+            description = "등록한 찜을 페이징으로 조회합니다." +
+                    "찜으로 등록된 상품을 조회하기 때문에 찜 여부를 나타내는 필드는 표시되지 않습니다."
     )
     @ApiResponse(content = @Content(schema = @Schema(implementation = ZzimResponse.class)))
     @SwaggerApiResponses(
@@ -72,28 +77,5 @@ public interface ZzimApi {
             @Parameter(hidden = true) Long userId,
             @ParameterObject
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
-    );
-
-    @Operation(
-            summary = "찜 삭제",
-            description = "사용자는 자신이 등록한 찜을 삭제할 수 있습니다."
-    )
-    @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(
-                    description = "찜 삭제 성공"
-            ),
-            errors = {
-                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
-                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
-                    @SwaggerApiFailedResponse(ExceptionType.ZZIM_NOT_FOUND),
-                    @SwaggerApiFailedResponse(ExceptionType.ZZIM_ACCESS_DENIED)
-            }
-    )
-    @DeleteMapping("/zzim/{zzimId}")
-    @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('USER')")
-    public ResponseEntity<ResponseBody<Void>> deleteZzim(
-            @Parameter(hidden = true) Long userId,
-            @PathVariable Long zzimId
     );
 }

--- a/src/main/java/com/uhdyl/backend/zzim/controller/ZzimController.java
+++ b/src/main/java/com/uhdyl/backend/zzim/controller/ZzimController.java
@@ -4,8 +4,9 @@ import com.uhdyl.backend.global.aop.AssignUserId;
 import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.global.response.ResponseBody;
 import com.uhdyl.backend.zzim.api.ZzimApi;
-import com.uhdyl.backend.zzim.dto.request.ZzimCreateRequest;
+import com.uhdyl.backend.zzim.dto.request.ZzimToggleRequest;
 import com.uhdyl.backend.zzim.dto.response.ZzimResponse;
+import com.uhdyl.backend.zzim.dto.response.ZzimToggleResponse;
 import com.uhdyl.backend.zzim.service.ZzimService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
@@ -22,17 +23,6 @@ import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessRespon
 public class ZzimController implements ZzimApi {
     private final ZzimService zzimService;
 
-    @PostMapping("/zzim")
-    @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('USER')")
-    public ResponseEntity<ResponseBody<Void>> createZzim(
-            Long userId,
-            @RequestBody ZzimCreateRequest request
-            ) {
-        zzimService.createZzim(userId, request.productId());
-        return ResponseEntity.ok(createSuccessResponse());
-    }
-
     @GetMapping("/zzim")
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasRole('USER')")
@@ -43,14 +33,13 @@ public class ZzimController implements ZzimApi {
         return ResponseEntity.ok(createSuccessResponse(zzimService.getZzims(userId, pageable)));
     }
 
-    @DeleteMapping("/zzim/{zzimId}")
+    @PostMapping("/zzim")
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasRole('USER')")
-    public ResponseEntity<ResponseBody<Void>> deleteZzim(
+    public ResponseEntity<ResponseBody<ZzimToggleResponse>> toggleZzim(
             Long userId,
-            @PathVariable Long zzimId
+            @RequestBody ZzimToggleRequest request
     ){
-        zzimService.deleteZzim(userId, zzimId);
-        return ResponseEntity.ok(createSuccessResponse());
+        return ResponseEntity.ok(createSuccessResponse(zzimService.toggleZzim(userId, request)));
     }
 }

--- a/src/main/java/com/uhdyl/backend/zzim/dto/request/ZzimToggleRequest.java
+++ b/src/main/java/com/uhdyl/backend/zzim/dto/request/ZzimToggleRequest.java
@@ -1,0 +1,6 @@
+package com.uhdyl.backend.zzim.dto.request;
+
+public record ZzimToggleRequest(
+        Long productId
+) {
+}

--- a/src/main/java/com/uhdyl/backend/zzim/dto/response/ZzimResponse.java
+++ b/src/main/java/com/uhdyl/backend/zzim/dto/response/ZzimResponse.java
@@ -4,6 +4,6 @@ public record ZzimResponse(
         Long id,
         String title,
         String imageUrl,
-        String price,
+        Long price,
         String sellerName
 ) {}

--- a/src/main/java/com/uhdyl/backend/zzim/dto/response/ZzimToggleResponse.java
+++ b/src/main/java/com/uhdyl/backend/zzim/dto/response/ZzimToggleResponse.java
@@ -1,0 +1,10 @@
+package com.uhdyl.backend.zzim.dto.response;
+
+public record ZzimToggleResponse(
+        ZzimResponse zzim,
+        boolean isZzim
+) {
+    public static ZzimToggleResponse to(ZzimResponse zzim, boolean isZzim){
+        return new ZzimToggleResponse(zzim, isZzim);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/zzim/repository/CustomZzimRepository.java
+++ b/src/main/java/com/uhdyl/backend/zzim/repository/CustomZzimRepository.java
@@ -2,8 +2,10 @@ package com.uhdyl.backend.zzim.repository;
 
 import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.zzim.dto.response.ZzimResponse;
+import com.uhdyl.backend.zzim.dto.response.ZzimToggleResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomZzimRepository {
-    GlobalPageResponse<ZzimResponse> findByUser(Long userId, Pageable pageable);
+    GlobalPageResponse<ZzimResponse> findAllByUser(Long userId, Pageable pageable);
+    ZzimResponse findZzim(Long userId, Long productId);
 }

--- a/src/main/java/com/uhdyl/backend/zzim/repository/ZzimRepository.java
+++ b/src/main/java/com/uhdyl/backend/zzim/repository/ZzimRepository.java
@@ -1,8 +1,16 @@
 package com.uhdyl.backend.zzim.repository;
 
+import com.uhdyl.backend.product.domain.Product;
+import com.uhdyl.backend.user.domain.User;
 import com.uhdyl.backend.zzim.domain.Zzim;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ZzimRepository extends JpaRepository<Zzim, Long>, CustomZzimRepository {
     boolean existsByUser_IdAndProduct_Id(Long userId, Long productId);
+
+    Zzim findByUserAndProduct(User user, Product product);
+
+    void deleteByUser_IdAndProduct_Id(Long userId, Long productId);
 }


### PR DESCRIPTION
## What is this PR?🔍
- 기존의 zzim 추가, 삭제 API를 제거하고 하나의 토클 API로 변경합니다.
- 
## Changes💻
- 토글로 찜의 상태를 변경 시 상태 변경을 진행한 상품의 정보와 상태 변경 결과를 나타내는 `isZzim`을 반환합니다.
- 찜한 상품 전체 조회 API를 호출 시 이미 찜으로 등록되어있는 상품을 조회하기에 `isZzim`을 함께 반환하지 않습니다.
-

## ScreenShot📷
