### PR TITLE
feat: 카테고리 별 상품 조회 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
+++ b/src/main/java/com/uhdyl/backend/global/exception/ExceptionType.java
@@ -64,6 +64,7 @@ public enum ExceptionType {
     CANT_UPDATE_PRODUCT(FORBIDDEN, "P005", "상품 소유자가 아니거나 이미 판매 완료된 상품입니다."),
     PRODUCT_COMPLETE_CONFLICT(CONFLICT, "P006", "동시 처리 충돌로 상품 완료 실패"),
     PRODUCT_COMPLETE_INTERRUPTED(INTERNAL_SERVER_ERROR, "P007", "재시도 중 인터럽트 발생"),
+    CATEGORY_NOT_FOUND(NOT_FOUND, "P007", "해당 카테고리가 존재하지 않습니다."),
 
 
     // Zzim

--- a/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
+++ b/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
@@ -6,10 +6,13 @@ import com.uhdyl.backend.global.config.swagger.SwaggerApiFailedResponse;
 import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
 import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
 import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.product.domain.Category;
 import com.uhdyl.backend.product.dto.request.ProductCreateRequest;
 import com.uhdyl.backend.product.dto.response.MyProductListResponse;
 import com.uhdyl.backend.product.dto.response.ProductCreateResponse;
+import com.uhdyl.backend.product.dto.response.ProductListResponse;
 import com.uhdyl.backend.product.dto.response.SalesStatsResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -136,5 +139,26 @@ public interface ProductAPI {
     ResponseEntity<ResponseBody<Void>> completeProduct(
             @Parameter(hidden = true) Long userId,
             @PathVariable Long productId
+    );
+
+    @Operation(
+            summary = "카테고리별 상품 조회",
+            description = "특정 카테고리에 속하는 상품 목록을 조회합니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(description = "카테고리별 상품 조회 성공"),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.INVALID_INPUT),
+                    @SwaggerApiFailedResponse(ExceptionType.CATEGORY_NOT_FOUND)
+            }
+    )
+    @GetMapping("/product/category/{category}")
+    ResponseEntity<ResponseBody<GlobalPageResponse<ProductListResponse>>> getProductsByCategory(
+            @Parameter(hidden = true) Long userId,
+            @PathVariable Category category,
+            @ParameterObject
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
     );
 }

--- a/src/main/java/com/uhdyl/backend/product/controller/ProductController.java
+++ b/src/main/java/com/uhdyl/backend/product/controller/ProductController.java
@@ -3,11 +3,14 @@ package com.uhdyl.backend.product.controller;
 import static com.uhdyl.backend.global.response.ResponseUtil.createSuccessResponse;
 
 import com.uhdyl.backend.global.aop.AssignUserId;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.global.response.ResponseBody;
 import com.uhdyl.backend.product.api.ProductAPI;
+import com.uhdyl.backend.product.domain.Category;
 import com.uhdyl.backend.product.dto.request.ProductCreateRequest;
 import com.uhdyl.backend.product.dto.response.MyProductListResponse;
 import com.uhdyl.backend.product.dto.response.ProductCreateResponse;
+import com.uhdyl.backend.product.dto.response.ProductListResponse;
 import com.uhdyl.backend.product.dto.response.SalesStatsResponse;
 import com.uhdyl.backend.product.service.ProductService;
 import lombok.RequiredArgsConstructor;
@@ -92,5 +95,19 @@ public class ProductController implements ProductAPI {
     ) {
         productService.completeProduct(userId, productId);
         return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    /**
+     * 카테고리 별 상품 조회 api
+     */
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    @GetMapping("/product/category/{category}")
+    public ResponseEntity<ResponseBody<GlobalPageResponse<ProductListResponse>>> getProductsByCategory(
+            Long userId,
+            @PathVariable Category category,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+            ) {
+        return ResponseEntity.ok(createSuccessResponse(productService.getProductsByCategory(userId, category, pageable)));
     }
 }

--- a/src/main/java/com/uhdyl/backend/product/domain/Product.java
+++ b/src/main/java/com/uhdyl/backend/product/domain/Product.java
@@ -4,6 +4,9 @@ import com.uhdyl.backend.global.base.BaseEntity;
 import com.uhdyl.backend.image.domain.Image;
 import com.uhdyl.backend.user.domain.User;
 import jakarta.persistence.CascadeType;
+import jakarta.persistence.CollectionTable;
+import jakarta.persistence.Column;
+import jakarta.persistence.ElementCollection;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -52,8 +55,11 @@ public class Product extends BaseEntity {
     @NotNull
     private long version = 0L;
 
+    @ElementCollection(targetClass = Category.class, fetch = FetchType.LAZY)
+    @CollectionTable(name = "product_category", joinColumns = @JoinColumn(name = "product_id"))
+    @Column(name = "category", nullable = false, columnDefinition = "VARCHAR(255)")
     @Enumerated(EnumType.STRING)
-    private Category category;
+    private List<Category> categories = new ArrayList<>();
 
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true)
     @JoinColumn(name = "product_id", nullable = false)
@@ -66,13 +72,13 @@ public class Product extends BaseEntity {
     private User user;
 
     @Builder
-    public Product(Long id, String name, String title, String description, boolean isSale, Long price, Category category, User user, long version) {
+    public Product(Long id, String name, String title, String description, boolean isSale, Long price, List<Category> categories, User user, long version) {
         this.name = name;
         this.title = title;
         this.description = description;
         this.isSale = isSale;
         this.price = price;
-        this.category = category;
+        this.categories = categories;
         this.user = user;
     }
 

--- a/src/main/java/com/uhdyl/backend/product/dto/request/ProductCreateRequest.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/request/ProductCreateRequest.java
@@ -4,7 +4,7 @@ import com.uhdyl.backend.product.domain.Category;
 import java.util.List;
 
 public record ProductCreateRequest(
-        Category category,
+        List<Category> categories,
         String breed,
         List<String> images,
         Long price,

--- a/src/main/java/com/uhdyl/backend/product/dto/response/ProductListResponse.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/response/ProductListResponse.java
@@ -6,14 +6,16 @@ import com.uhdyl.backend.product.domain.Product;
 public record ProductListResponse(
         Long id,
         String name,
+        String title,
         Long price,
         String sellerName,
         String mainImageUrl,
         boolean isCompleted
 ) {
     @QueryProjection
-    public ProductListResponse(Long id, String name, Long price, String sellerName, String mainImageUrl, boolean isCompleted) {
+    public ProductListResponse(Long id, String name, String title, Long price, String sellerName, String mainImageUrl, boolean isCompleted) {
         this.id = id;
+        this.title = title;
         this.name = name;
         this.price = price;
         this.sellerName = sellerName;
@@ -25,6 +27,7 @@ public record ProductListResponse(
         return new ProductListResponse(
                 product.getId(),
                 product.getName(),
+                product.getTitle(),
                 product.getPrice(),
                 product.getUser().getNickname(),
                 product.getImages().get(0).getImageUrl(),

--- a/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepository.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepository.java
@@ -1,10 +1,14 @@
 package com.uhdyl.backend.product.repository;
 
+import com.uhdyl.backend.global.response.GlobalPageResponse;
+import com.uhdyl.backend.product.domain.Category;
 import com.uhdyl.backend.product.dto.response.MyProductListResponse;
+import com.uhdyl.backend.product.dto.response.ProductListResponse;
 import com.uhdyl.backend.product.dto.response.SalesStatsResponse;
 import org.springframework.data.domain.Pageable;
 
 public interface CustomProductRepository {
     MyProductListResponse getMyProducts(Long userId, Pageable pageable);
     SalesStatsResponse getSalesStats(Long userId);
+    GlobalPageResponse<ProductListResponse> getProductsByCategory(Category category, Pageable pageable);
 }

--- a/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
@@ -32,6 +32,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                 .select(Projections.constructor(ProductListResponse.class,
                         product.id,
                         product.name,
+                        product.title,
                         product.price,
                         product.user.name,
                         image.imageUrl.min(),
@@ -40,7 +41,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                 .from(product)
                 .leftJoin(product.images,image)
                 .where(product.user.id.eq(userId))
-                .groupBy(product.id, product.name, product.price, product.user.name, product.isSale, image.imageOrder)
+                .groupBy(product.id, product.name, product.title, product.price, product.user.name, product.isSale, image.imageOrder)
                 .orderBy(product.createdAt.desc(), image.imageOrder.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -98,6 +99,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                 .select(Projections.constructor(ProductListResponse.class,
                         product.id,
                         product.name,
+                        product.title,
                         product.price,
                         product.user.name,
                         image.imageUrl.min(),
@@ -107,7 +109,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                 .leftJoin(product.images, image)
                 .where(product.categories.any().eq(category)
                         .and(product.isSale.eq(true)))
-                .groupBy(product.id, product.name, product.price, product.user.name, product.isSale, image.imageOrder)
+                .groupBy(product.id, product.name, product.title, product.price, product.user.name, product.isSale, image.imageOrder)
                 .orderBy(product.createdAt.desc(), image.imageOrder.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
@@ -102,15 +102,14 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                         product.title,
                         product.price,
                         product.user.name,
-                        image.imageUrl.min(),
+                        image.imageUrl,
                         product.isSale.not()
                 ))
                 .from(product)
-                .leftJoin(product.images, image)
+                .leftJoin(product.images, image).on(image.imageOrder.eq(0L))
                 .where(product.categories.any().eq(category)
                         .and(product.isSale.eq(true)))
-                .groupBy(product.id, product.name, product.title, product.price, product.user.name, product.isSale, image.imageOrder)
-                .orderBy(product.createdAt.desc(), image.imageOrder.asc())
+                .orderBy(product.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/uhdyl/backend/product/service/ProductService.java
+++ b/src/main/java/com/uhdyl/backend/product/service/ProductService.java
@@ -63,7 +63,7 @@ public class ProductService {
                 .description(aiResult.description())
                 .isSale(true) // true = 거래 가능
                 .price(request.price())
-                .category(request.category())
+                .categories(request.categories())
                 .user(user)
                 .build();
 

--- a/src/main/java/com/uhdyl/backend/product/service/ProductService.java
+++ b/src/main/java/com/uhdyl/backend/product/service/ProductService.java
@@ -2,11 +2,14 @@ package com.uhdyl.backend.product.service;
 
 import com.uhdyl.backend.global.exception.BusinessException;
 import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.image.domain.Image;
+import com.uhdyl.backend.product.domain.Category;
 import com.uhdyl.backend.product.domain.Product;
 import com.uhdyl.backend.product.dto.request.ProductCreateRequest;
 import com.uhdyl.backend.product.dto.response.MyProductListResponse;
 import com.uhdyl.backend.product.dto.response.ProductCreateResponse;
+import com.uhdyl.backend.product.dto.response.ProductListResponse;
 import com.uhdyl.backend.product.dto.response.SalesStatsResponse;
 import com.uhdyl.backend.product.repository.ProductRepository;
 import com.uhdyl.backend.user.domain.User;
@@ -139,5 +142,13 @@ public class ProductService {
     @Recover
     public void recover(Exception e, Long userId, Long productId) {
         throw new BusinessException(ExceptionType.PRODUCT_COMPLETE_CONFLICT);
+    }
+
+    @Transactional(readOnly = true)
+    public GlobalPageResponse<ProductListResponse> getProductsByCategory(Long userId, Category category, Pageable pageable){
+        if(!userRepository.existsById(userId))
+            throw new BusinessException(ExceptionType.USER_NOT_FOUND);
+
+        return productRepository.getProductsByCategory(category, pageable);
     }
 }

--- a/src/main/java/com/uhdyl/backend/product/service/ProductService.java
+++ b/src/main/java/com/uhdyl/backend/product/service/ProductService.java
@@ -11,7 +11,6 @@ import com.uhdyl.backend.product.dto.response.SalesStatsResponse;
 import com.uhdyl.backend.product.repository.ProductRepository;
 import com.uhdyl.backend.user.domain.User;
 import com.uhdyl.backend.user.repository.UserRepository;
-import jakarta.persistence.OptimisticLockException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.dao.OptimisticLockingFailureException;
@@ -31,7 +30,6 @@ public class ProductService {
     private final ProductRepository productRepository;
     private final UserRepository userRepository;
     private final AiContentService aiContentService;
-    private static final int RETRY_COUNT = 3;
 
     @Transactional
     public ProductCreateResponse createProduct(Long userId, ProductCreateRequest request) {


### PR DESCRIPTION
## What is this PR?🔍

- 하나의 상품에 여러 카테고리를 저장할 수 있도록 변경
- 카테고리별 상품 조회 시 상품 목록 반환 기능 추가
- 상품 조회 시 이름(name) 대신 제목(title)을 가져오도록 DTO 및 QueryDSL 로직 수정

## Changes💻

- Product 엔티티의 categories 필드 다중 저장 가능하도록 수정
- 카테고리별 상품 조회 서비스 및 레포지토리 구현
- QueryDSL 조회 시 ProductListResponse에서 title 추가

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 카테고리별 상품 조회 API 추가: 인증 사용자 대상, 페이지네이션(기본 10개), 최신순 정렬로 조회 가능.

- Changes
  - 상품 등록/저장이 다중 카테고리 지원으로 확장되어 복수 선택 가능.
  - 상품 목록 응답에 title(제목) 필드 추가로 목록 정보 강화.
  - 존재하지 않는 카테고리 요청에 대해 ‘카테고리 없음’ 오류 응답을 명확히 제공.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->