### PR TITLE
feat: 상품 상세 조회 API 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
+++ b/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
@@ -155,6 +155,9 @@ public interface ProductAPI {
                     @SwaggerApiFailedResponse(ExceptionType.CATEGORY_NOT_FOUND)
             }
     )
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     @GetMapping("/product/category/{category}")
     ResponseEntity<ResponseBody<GlobalPageResponse<ProductListResponse>>> getProductsByCategory(
             @Parameter(hidden = true) Long userId,
@@ -176,6 +179,9 @@ public interface ProductAPI {
                     @SwaggerApiFailedResponse(ExceptionType.PRODUCT_NOT_FOUND)
             }
     )
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     @GetMapping("/product/{productId}")
     ResponseEntity<ResponseBody<ProductDetailResponse>> getProductDetail(
             @Parameter(hidden = true) Long userId,

--- a/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
+++ b/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
@@ -12,6 +12,7 @@ import com.uhdyl.backend.product.domain.Category;
 import com.uhdyl.backend.product.dto.request.ProductCreateRequest;
 import com.uhdyl.backend.product.dto.response.MyProductListResponse;
 import com.uhdyl.backend.product.dto.response.ProductCreateResponse;
+import com.uhdyl.backend.product.dto.response.ProductDetailResponse;
 import com.uhdyl.backend.product.dto.response.ProductListResponse;
 import com.uhdyl.backend.product.dto.response.SalesStatsResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -160,5 +161,24 @@ public interface ProductAPI {
             @PathVariable Category category,
             @ParameterObject
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
+    );
+
+    @Operation(
+            summary = "상품 (게시글) 상세보기",
+            description = "특정 상품의 상세 정보를 조회합니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(description = "삼품 상세 조회 성공"),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.INVALID_INPUT),
+                    @SwaggerApiFailedResponse(ExceptionType.PRODUCT_NOT_FOUND)
+            }
+    )
+    @GetMapping("/product/{productId}")
+    ResponseEntity<ResponseBody<ProductDetailResponse>> getProductDetail(
+            @Parameter(hidden = true) Long userId,
+            @PathVariable Long productId
     );
 }

--- a/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
+++ b/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
@@ -171,7 +171,7 @@ public interface ProductAPI {
             description = "특정 상품의 상세 정보를 조회합니다."
     )
     @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(description = "삼품 상세 조회 성공"),
+            success = @SwaggerApiSuccessResponse(description = "상품 상세 조회 성공"),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),

--- a/src/main/java/com/uhdyl/backend/product/controller/ProductController.java
+++ b/src/main/java/com/uhdyl/backend/product/controller/ProductController.java
@@ -10,6 +10,7 @@ import com.uhdyl.backend.product.domain.Category;
 import com.uhdyl.backend.product.dto.request.ProductCreateRequest;
 import com.uhdyl.backend.product.dto.response.MyProductListResponse;
 import com.uhdyl.backend.product.dto.response.ProductCreateResponse;
+import com.uhdyl.backend.product.dto.response.ProductDetailResponse;
 import com.uhdyl.backend.product.dto.response.ProductListResponse;
 import com.uhdyl.backend.product.dto.response.SalesStatsResponse;
 import com.uhdyl.backend.product.service.ProductService;
@@ -109,5 +110,18 @@ public class ProductController implements ProductAPI {
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable
             ) {
         return ResponseEntity.ok(createSuccessResponse(productService.getProductsByCategory(userId, category, pageable)));
+    }
+
+    /**
+     * 상품 상세 조회 api
+     */
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    @GetMapping("/product/{productId}")
+    public ResponseEntity<ResponseBody<ProductDetailResponse>> getProductDetail(
+            Long userId,
+            @PathVariable Long productId
+    ) {
+        return ResponseEntity.ok(createSuccessResponse(productService.getProductDetail(userId, productId)));
     }
 }

--- a/src/main/java/com/uhdyl/backend/product/dto/response/ProductDetailResponse.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/response/ProductDetailResponse.java
@@ -1,0 +1,16 @@
+package com.uhdyl.backend.product.dto.response;
+
+import java.util.List;
+
+public record ProductDetailResponse(
+        Long id,
+        String name,
+        String title,
+        Long price,
+        String description,
+        String sellerName,
+        String sellerPicture,
+        Double sellerRating,
+        List<String> images,
+        boolean isCompleted
+) {}

--- a/src/main/java/com/uhdyl/backend/product/dto/response/ProductListResponse.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/response/ProductListResponse.java
@@ -9,16 +9,18 @@ public record ProductListResponse(
         String title,
         Long price,
         String sellerName,
+        String sellerPicture,
         String mainImageUrl,
         boolean isCompleted
 ) {
     @QueryProjection
-    public ProductListResponse(Long id, String name, String title, Long price, String sellerName, String mainImageUrl, boolean isCompleted) {
+    public ProductListResponse(Long id, String name, String title, Long price, String sellerName, String sellerPicture, String mainImageUrl, boolean isCompleted) {
         this.id = id;
         this.title = title;
         this.name = name;
         this.price = price;
         this.sellerName = sellerName;
+        this.sellerPicture = sellerPicture;
         this.mainImageUrl = mainImageUrl;
         this.isCompleted = isCompleted;
     }
@@ -30,6 +32,7 @@ public record ProductListResponse(
                 product.getTitle(),
                 product.getPrice(),
                 product.getUser().getNickname(),
+                product.getUser().getPicture(),
                 product.getImages().get(0).getImageUrl(),
                 product.isSale()
         );

--- a/src/main/java/com/uhdyl/backend/product/dto/response/SalesStatsResponse.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/response/SalesStatsResponse.java
@@ -1,8 +1,9 @@
 package com.uhdyl.backend.product.dto.response;
 
 public record SalesStatsResponse(
-        String name,
+        String sellerName,
         Long salesCount,
-        Long salesRevenue
+        Long salesRevenue,
+        String sellerPicture
 ) {
 }

--- a/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepository.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepository.java
@@ -3,6 +3,7 @@ package com.uhdyl.backend.product.repository;
 import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.product.domain.Category;
 import com.uhdyl.backend.product.dto.response.MyProductListResponse;
+import com.uhdyl.backend.product.dto.response.ProductDetailResponse;
 import com.uhdyl.backend.product.dto.response.ProductListResponse;
 import com.uhdyl.backend.product.dto.response.SalesStatsResponse;
 import org.springframework.data.domain.Pageable;
@@ -11,4 +12,5 @@ public interface CustomProductRepository {
     MyProductListResponse getMyProducts(Long userId, Pageable pageable);
     SalesStatsResponse getSalesStats(Long userId);
     GlobalPageResponse<ProductListResponse> getProductsByCategory(Category category, Pageable pageable);
+    ProductDetailResponse getProductDetail(Long productId);
 }

--- a/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
@@ -40,13 +40,14 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                         product.title,
                         product.price,
                         product.user.name,
+                        product.user.picture,
                         image.imageUrl.min(),
                         product.isSale.not()
                 ))
                 .from(product)
                 .leftJoin(product.images,image)
                 .where(product.user.id.eq(userId))
-                .groupBy(product.id, product.name, product.title, product.price, product.user.name, product.isSale, image.imageOrder)
+                .groupBy(product.id, product.name, product.title, product.price, product.user.name, product.user.picture, product.isSale, image.imageOrder)
                 .orderBy(product.createdAt.desc(), image.imageOrder.asc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -83,16 +84,18 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                 .select(Projections.constructor(SalesStatsResponse.class,
                         user.name.coalesce(""),
                         product.count(),
-                        product.price.sumLong().coalesce(0L)
+                        product.price.sumLong().coalesce(0L),
+                        user.picture.coalesce("")
+
                 ))
                 .from(user)
                 .leftJoin(user.products, product)
                 .on(product.isSale.eq(false))
                 .where(user.id.eq(userId))
-                .groupBy(user.id, user.name)
+                .groupBy(user.id, user.name, user.picture)
                 .fetchOne();
 
-        return stats != null ? stats : new SalesStatsResponse("", 0L, 0L);
+        return stats != null ? stats : new SalesStatsResponse("", 0L, 0L, "");
     }
 
     @Override

--- a/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
@@ -46,10 +46,10 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                         product.isSale.not()
                 ))
                 .from(product)
-                .leftJoin(product.images,image)
+                .leftJoin(product.images, image).on(image.imageOrder.eq(0L))
                 .where(product.user.id.eq(userId))
-                .groupBy(product.id, product.name, product.title, product.price, user.nickname, user.name, user.picture, product.isSale, image.imageOrder)
-                .orderBy(product.createdAt.desc(), image.imageOrder.asc())
+                .groupBy(product.id, product.name, product.title, product.price, user.nickname, user.name, user.picture, product.isSale)
+                .orderBy(product.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -112,6 +112,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                         product.title,
                         product.price,
                         user.nickname.coalesce(user.name).coalesce(""),
+                        user.picture.coalesce(""),
                         image.imageUrl,
                         product.isSale.not()
                 ))

--- a/src/main/java/com/uhdyl/backend/product/service/ProductService.java
+++ b/src/main/java/com/uhdyl/backend/product/service/ProductService.java
@@ -9,6 +9,7 @@ import com.uhdyl.backend.product.domain.Product;
 import com.uhdyl.backend.product.dto.request.ProductCreateRequest;
 import com.uhdyl.backend.product.dto.response.MyProductListResponse;
 import com.uhdyl.backend.product.dto.response.ProductCreateResponse;
+import com.uhdyl.backend.product.dto.response.ProductDetailResponse;
 import com.uhdyl.backend.product.dto.response.ProductListResponse;
 import com.uhdyl.backend.product.dto.response.SalesStatsResponse;
 import com.uhdyl.backend.product.repository.ProductRepository;
@@ -150,5 +151,13 @@ public class ProductService {
             throw new BusinessException(ExceptionType.USER_NOT_FOUND);
 
         return productRepository.getProductsByCategory(category, pageable);
+    }
+
+    @Transactional(readOnly = true)
+    public ProductDetailResponse getProductDetail(Long userId, Long productId) {
+        if(!userRepository.existsById(userId))
+            throw new BusinessException(ExceptionType.USER_NOT_FOUND);
+
+        return productRepository.getProductDetail(productId);
     }
 }


### PR DESCRIPTION
## What is this PR?🔍

- 주문 상세보기 API를 추가하였습니다.
- 사용자 관련 DTO에 프로필 사진 필드를 추가하여, 판매자 정보와 함께 프로필 이미지를 반환하도록 수정하였습니다.

## Changes💻

- 상품 상세 조회 API 구현 (GET /product/{id})
- 판매자 프로필 정보 포함 (이름, 프로필 사진, 평점)
- 상품 이미지 목록 및 거래 상태 반환
- SalesStatsResponse에 sellerPicture 필드 추가
- ProductListResponse에 sellerPicture 필드 추가

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 단일 상품 상세 조회가 추가되어, 로그인 사용자는 상품 설명, 이미지 목록, 판매자 이름/프로필 이미지, 판매자 평점, 거래 상태 등을 한 화면에서 확인할 수 있습니다.
- 개선
  - 상품 목록 카드에 판매자 프로필 이미지가 노출되어 판매자 식별이 쉬워졌습니다.
  - 판매자 매출 통계에 프로필 이미지가 포함되어 정보 파악이 더 쉬워졌습니다.
  - 카테고리별 상품 목록 접근이 로그인(사용자)으로 제한되어 보안이 강화되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->