### PR TITLE
fix: 상품 등록과 AI 글쓰기 분리 및 이미지 저장 로직 수정

### DIFF
--- a/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
+++ b/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
@@ -51,7 +51,7 @@ public interface ProductAPI {
     )
 
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('FARMER')")
     @PostMapping("/product/ai-generate")
     ResponseEntity<ResponseBody<AiGeneratedContentResponse>> generateAiContent(
             @Parameter(hidden = true) Long userId,
@@ -73,7 +73,7 @@ public interface ProductAPI {
     )
 
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('FARMER')")
     @PostMapping("/product")
     ResponseEntity<ResponseBody<ProductCreateResponse>> createProduct(
             @Parameter(hidden = true) Long userId,
@@ -96,7 +96,7 @@ public interface ProductAPI {
     )
 
     @DeleteMapping("/product/{productId}")
-    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('FARMER')")
     @AssignUserId
     public ResponseEntity<ResponseBody<Void>> deleteProduct(
             @Parameter(hidden = true) Long userId,

--- a/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
+++ b/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
@@ -9,7 +9,9 @@ import com.uhdyl.backend.global.exception.ExceptionType;
 import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.global.response.ResponseBody;
 import com.uhdyl.backend.product.domain.Category;
-import com.uhdyl.backend.product.dto.request.ProductCreateRequest;
+import com.uhdyl.backend.product.dto.request.ProductAiGenerateRequest;
+import com.uhdyl.backend.product.dto.request.ProductCreateWithAiContentRequest;
+import com.uhdyl.backend.product.dto.response.AiGeneratedContentResponse;
 import com.uhdyl.backend.product.dto.response.MyProductListResponse;
 import com.uhdyl.backend.product.dto.response.ProductCreateResponse;
 import com.uhdyl.backend.product.dto.response.ProductDetailResponse;
@@ -35,11 +37,11 @@ import org.springframework.web.bind.annotation.RequestBody;
 public interface ProductAPI {
 
     @Operation(
-            summary = "상품 등록",
-            description = "판매자가 상품을 등록합니다. 제목과 설명은 AI가 생성합니다."
+            summary = "AI 글 작성",
+            description = "AI가 상품 정보를 바탕으로 제목과 설명을 생성합니다."
     )
     @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(description = "상품 등록 성공"),
+            success = @SwaggerApiSuccessResponse(description = "AI 글 생성 성공"),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
@@ -50,10 +52,32 @@ public interface ProductAPI {
 
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    @PostMapping("/product/ai-generate")
+    ResponseEntity<ResponseBody<AiGeneratedContentResponse>> generateAiContent(
+            @Parameter(hidden = true) Long userId,
+            @RequestBody ProductAiGenerateRequest request
+    );
+
+    @Operation(
+            summary = "상품 등록",
+            description = "AI로 생성된 글을 바탕으로 상품을 등록합니다. 제목과 설명은 사용자가 수정할 수 있습니다."
+    )
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(description = "상품 등록 성공"),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.INVALID_INPUT),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FARMER)
+            }
+    )
+
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
     @PostMapping("/product")
     ResponseEntity<ResponseBody<ProductCreateResponse>> createProduct(
             @Parameter(hidden = true) Long userId,
-            @RequestBody ProductCreateRequest request
+            @RequestBody ProductCreateWithAiContentRequest request
     );
 
     @Operation(

--- a/src/main/java/com/uhdyl/backend/product/controller/ProductController.java
+++ b/src/main/java/com/uhdyl/backend/product/controller/ProductController.java
@@ -7,7 +7,9 @@ import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.global.response.ResponseBody;
 import com.uhdyl.backend.product.api.ProductAPI;
 import com.uhdyl.backend.product.domain.Category;
-import com.uhdyl.backend.product.dto.request.ProductCreateRequest;
+import com.uhdyl.backend.product.dto.request.ProductAiGenerateRequest;
+import com.uhdyl.backend.product.dto.request.ProductCreateWithAiContentRequest;
+import com.uhdyl.backend.product.dto.response.AiGeneratedContentResponse;
 import com.uhdyl.backend.product.dto.response.MyProductListResponse;
 import com.uhdyl.backend.product.dto.response.ProductCreateResponse;
 import com.uhdyl.backend.product.dto.response.ProductDetailResponse;
@@ -34,13 +36,24 @@ public class ProductController implements ProductAPI {
     private final ProductService productService;
 
     /**
-     * 상품 등록 api
+     * AI 글 작성 API (1단계 - AI 글 생성)
+     */
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    @PostMapping("/product/ai-generate")
+    public ResponseEntity<ResponseBody<AiGeneratedContentResponse>> generateAiContent(Long userId, ProductAiGenerateRequest request) {
+        AiGeneratedContentResponse response = productService.generateAiContent(userId, request);
+        return ResponseEntity.ok(createSuccessResponse(response));
+    }
+
+    /**
+     * 상품 등록 API (2단계 - AI로 생성된 글로 등록)
      */
     @AssignUserId
     @PreAuthorize("isAuthenticated() and hasRole('USER')")
     @PostMapping("/product")
-    public ResponseEntity<ResponseBody<ProductCreateResponse>> createProduct(Long userId, ProductCreateRequest request) {
-        ProductCreateResponse response = productService.createProduct(userId, request);
+    public ResponseEntity<ResponseBody<ProductCreateResponse>> createProduct(Long userId, ProductCreateWithAiContentRequest request) {
+        ProductCreateResponse response = productService.createProductWithGeneratedContent(userId, request);
         return ResponseEntity.ok(createSuccessResponse(response));
     }
 

--- a/src/main/java/com/uhdyl/backend/product/controller/ProductController.java
+++ b/src/main/java/com/uhdyl/backend/product/controller/ProductController.java
@@ -39,7 +39,7 @@ public class ProductController implements ProductAPI {
      * AI 글 작성 API (1단계 - AI 글 생성)
      */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('FARMER')")
     @PostMapping("/product/ai-generate")
     public ResponseEntity<ResponseBody<AiGeneratedContentResponse>> generateAiContent(Long userId, ProductAiGenerateRequest request) {
         AiGeneratedContentResponse response = productService.generateAiContent(userId, request);
@@ -50,7 +50,7 @@ public class ProductController implements ProductAPI {
      * 상품 등록 API (2단계 - AI로 생성된 글로 등록)
      */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('FARMER')")
     @PostMapping("/product")
     public ResponseEntity<ResponseBody<ProductCreateResponse>> createProduct(Long userId, ProductCreateWithAiContentRequest request) {
         ProductCreateResponse response = productService.createProductWithGeneratedContent(userId, request);
@@ -61,7 +61,7 @@ public class ProductController implements ProductAPI {
      * 상품 삭제 api
      */
     @AssignUserId
-    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    @PreAuthorize("isAuthenticated() and hasRole('FARMER')")
     @DeleteMapping("/product/{productId}")
     public ResponseEntity<ResponseBody<Void>> deleteProduct(
             Long userId,

--- a/src/main/java/com/uhdyl/backend/product/domain/Product.java
+++ b/src/main/java/com/uhdyl/backend/product/domain/Product.java
@@ -52,8 +52,7 @@ public class Product extends BaseEntity {
     private Long price;
 
     @Version
-    @NotNull
-    private long version = 0L;
+    private Long version;
 
     @ElementCollection(targetClass = Category.class, fetch = FetchType.LAZY)
     @CollectionTable(name = "product_category", joinColumns = @JoinColumn(name = "product_id"))
@@ -72,7 +71,7 @@ public class Product extends BaseEntity {
     private User user;
 
     @Builder
-    public Product(Long id, String name, String title, String description, boolean isSale, Long price, List<Category> categories, User user, long version) {
+    public Product(Long id, String name, String title, String description, boolean isSale, Long price, List<Category> categories, User user, Long version) {
         this.name = name;
         this.title = title;
         this.description = description;
@@ -80,6 +79,7 @@ public class Product extends BaseEntity {
         this.price = price;
         this.categories = categories;
         this.user = user;
+        this.version = version;
     }
 
     public void addImage(Image image) {

--- a/src/main/java/com/uhdyl/backend/product/dto/request/ProductAiGenerateRequest.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/request/ProductAiGenerateRequest.java
@@ -3,10 +3,10 @@ package com.uhdyl.backend.product.dto.request;
 import com.uhdyl.backend.product.domain.Category;
 import java.util.List;
 
-public record ProductCreateRequest(
+public record ProductAiGenerateRequest(
         List<Category> categories,
         String breed,
         List<String> images,
         Long price,
         String tone
-){}
+) {}

--- a/src/main/java/com/uhdyl/backend/product/dto/request/ProductCreateWithAiContentRequest.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/request/ProductCreateWithAiContentRequest.java
@@ -1,0 +1,13 @@
+package com.uhdyl.backend.product.dto.request;
+
+import com.uhdyl.backend.product.domain.Category;
+import java.util.List;
+
+public record ProductCreateWithAiContentRequest(
+        List<Category> categories,
+        String breed,
+        List<String> images,
+        Long price,
+        String title,
+        String description
+) {}

--- a/src/main/java/com/uhdyl/backend/product/dto/request/ProductCreateWithAiContentRequest.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/request/ProductCreateWithAiContentRequest.java
@@ -6,8 +6,13 @@ import java.util.List;
 public record ProductCreateWithAiContentRequest(
         List<Category> categories,
         String breed,
-        List<String> images,
+        List<ImageRequest> images,
         Long price,
         String title,
         String description
-) {}
+) {
+    public record ImageRequest(
+            String url,
+            String publicId
+    ) {}
+}

--- a/src/main/java/com/uhdyl/backend/product/dto/response/AiGeneratedContentResponse.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/response/AiGeneratedContentResponse.java
@@ -1,0 +1,14 @@
+package com.uhdyl.backend.product.dto.response;
+
+import com.uhdyl.backend.product.domain.Category;
+import java.util.List;
+
+public record AiGeneratedContentResponse(
+        String title,
+        String description,
+        String breed,
+        Long price,
+        List<String> images,
+        List<Category> categories,
+        String tone
+) {}

--- a/src/main/java/com/uhdyl/backend/product/service/ProductService.java
+++ b/src/main/java/com/uhdyl/backend/product/service/ProductService.java
@@ -97,9 +97,9 @@ public class ProductService {
 
         if (request.images() != null && !request.images().isEmpty()) {
             long order = 0;
-            for (String imageUrl : request.images()) {
-                if (imageUrl == null || imageUrl.isBlank()) continue;
-                product.addImage(new Image(imageUrl, order++, null));
+            for (ProductCreateWithAiContentRequest.ImageRequest imageRequest : request.images()){
+                if (imageRequest.url() == null || imageRequest.url().isBlank()) continue;
+                product.addImage(new Image(imageRequest.url(), order++, imageRequest.publicId()));
             }
         }
 

--- a/src/main/java/com/uhdyl/backend/product/service/ProductService.java
+++ b/src/main/java/com/uhdyl/backend/product/service/ProductService.java
@@ -115,63 +115,6 @@ public class ProductService {
         );
     }
 
-//
-//    @Transactional
-//    public ProductCreateResponse createProduct(Long userId, ProductCreateWithAiContentRequest request) {
-//        AiContentService.AiResult aiResult = callAiService(request);
-//
-//        return saveProduct(userId, request, aiResult);
-//    }
-//
-//    private AiContentService.AiResult callAiService(ProductCreateWithAiContentRequest request) {
-//        try {
-//            return aiContentService.generateContent(
-//                    request.breed(),
-//                    request.price(),
-//                    request.tone(),
-//                    request.images()
-//            );
-//        } catch (Exception e) {
-//            log.error("AI 콘텐츠 생성 실패 - breed: {}, price: {}", request.breed(), request.price(), e);
-//            throw new BusinessException(ExceptionType.AI_GENERATION_FAILED);
-//        }
-//    }
-//
-//    @Transactional
-//    public ProductCreateResponse saveProduct(Long userId, ProductCreateWithAiContentRequest request, AiContentService.AiResult aiResult){
-//        User user = userRepository.findById(userId)
-//                .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
-//
-//        Product product = Product.builder()
-//                .name(request.breed())
-//                .title(aiResult.title())
-//                .description(aiResult.description())
-//                .isSale(true) // true = 거래 가능
-//                .price(request.price())
-//                .categories(request.categories())
-//                .user(user)
-//                .build();
-//
-//        if (request.images() != null && !request.images().isEmpty()) {
-//            long order = 0;
-//            for (String imageUrl : request.images()) {
-//                if (imageUrl == null || imageUrl.isBlank()) continue;
-//                product.addImage(new Image(imageUrl, order++, null));
-//            }
-//        }
-//
-//        Product saved = productRepository.save(product);
-//
-//        return new ProductCreateResponse(
-//                saved.getId(),
-//                saved.getTitle(),
-//                saved.getDescription(),
-//                saved.getPrice(),
-//                saved.getImages().stream().map(Image::getImageUrl).toList(),
-//                saved.isSale()
-//        );
-//    }
-
     @Transactional
     public void deleteProduct(Long userId, Long productId) {
         User user = userRepository.findById(userId)
@@ -184,7 +127,6 @@ public class ProductService {
             throw new BusinessException(ExceptionType.CANT_DELETE_PRODUCT);
         }
 
-        user.removeProduct(product);
         productRepository.delete(product);
     }
 


### PR DESCRIPTION
## What is this PR?🔍

- 기존에는 `createProduct` 메서드 내에서 AI 생성 + 저장이 한 트랜잭션에서 처리되어 문제가 있어 이를 분리하였습니다.
- 상품 등록 시 이미지의 `publicId`를 `null`로 저장했는데, 관리/삭제 시 불편함이 있어 등록 시점에 `publicId`도 함께 저장하도록 수정했습니다.

## Changes💻

- **상품 등록 프로세스 개선**
    - `"AI 글 작성"` 버튼 클릭 → `/product/ai-generate` 호출
    - 생성된 글을 사용자에게 보여주고 수정 가능
    - `"상품 등록"` 버튼 클릭 → `/product` 호출로 최종 저장
- **이미지 저장 로직 개선**
    - DTO에 `ImageRequest(url, publicId)` 레코드 추가
    - 서비스에서 `url`, `publicId` 함께 넘겨 `Image` 생성

## ScreenShot📷
