### PR TITLE
feat: 각 API의 Response DTO 명시 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
+++ b/src/main/java/com/uhdyl/backend/product/api/ProductAPI.java
@@ -48,7 +48,9 @@ public interface ProductAPI {
     )
     @ApiResponse(content = @Content(schema = @Schema(implementation = AiGeneratedContentResponse.class)))
     @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(description = "AI 글 생성 성공"),
+            success = @SwaggerApiSuccessResponse(
+                    response = AiGeneratedContentResponse.class,
+                    description = "AI 글 생성 성공"),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
@@ -72,7 +74,9 @@ public interface ProductAPI {
     )
     @ApiResponse(content = @Content(schema = @Schema(implementation = ProductCreateResponse.class)))
     @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(description = "상품 등록 성공"),
+            success = @SwaggerApiSuccessResponse(
+                    response = ProductCreateResponse.class,
+                    description = "상품 등록 성공"),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
@@ -118,7 +122,9 @@ public interface ProductAPI {
     )
     @ApiResponse(content = @Content(schema = @Schema(implementation = ProductListResponse.class)))
     @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(description = "전체 상품 목록 조회 성공"),
+            success = @SwaggerApiSuccessResponse(
+                    responsePage = ProductListResponse.class,
+                    description = "전체 상품 목록 조회 성공"),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.INVALID_INPUT),
@@ -141,7 +147,9 @@ public interface ProductAPI {
     )
     @ApiResponse(content = @Content(schema = @Schema(implementation = MyProductListResponse.class)))
     @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(description = "상품 목록 조회 성공"),
+            success = @SwaggerApiSuccessResponse(
+                    response = MyProductListResponse.class,
+                    description = "상품 목록 조회 성공"),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.INVALID_INPUT),
@@ -164,7 +172,9 @@ public interface ProductAPI {
     )
     @ApiResponse(content = @Content(schema = @Schema(implementation = SalesStatsResponse.class)))
     @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(description = "판매 현황 조회 성공"),
+            success = @SwaggerApiSuccessResponse(
+                    response = SalesStatsResponse.class,
+                    description = "판매 현황 조회 성공"),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND)
@@ -206,7 +216,9 @@ public interface ProductAPI {
     )
     @ApiResponse(content = @Content(schema = @Schema(implementation = ProductDetailResponse.class)))
     @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(description = "상품 상세 조회 성공"),
+            success = @SwaggerApiSuccessResponse(
+                    response = ProductDetailResponse.class,
+                    description = "상품 상세 조회 성공"),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
@@ -231,7 +243,9 @@ public interface ProductAPI {
     )
     @ApiResponse(content = @Content(schema = @Schema(implementation = ProductListResponse.class)))
     @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(description = "상품 검색 성공"),
+            success = @SwaggerApiSuccessResponse(
+                    responsePage = ProductListResponse.class,
+                    description = "상품 검색 성공"),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),

--- a/src/main/java/com/uhdyl/backend/user/api/UserApi.java
+++ b/src/main/java/com/uhdyl/backend/user/api/UserApi.java
@@ -73,7 +73,9 @@ public interface UserApi {
     )
     @ApiResponse(content = @Content(schema = @Schema(implementation = LocationResponse.class)))
     @SwaggerApiResponses(
-            success = @SwaggerApiSuccessResponse(description = "위치 조회 성공"),
+            success = @SwaggerApiSuccessResponse(
+                    response = LocationResponse.class,
+                    description = "위치 조회 성공"),
             errors = {
                     @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
                     @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),


### PR DESCRIPTION
## What is this PR?🔍

- 스웨거 상품 및 사용자 도메인에 Response DTO 명시하지 않아서 응답이 보이지 않는 문제를 해결하였습니다.

## Changes💻

- `@ApiResponse(content = @Content(schema = @Schema(implementation = XXX.class)))`를 Response DTO가 있는 곳에 추가하였습니다.

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 문서화
  - 제품 관련 다수 API에 명시적 응답 스키마를 추가하여 자동 생성된 API 문서의 정확성과 가독성 향상.
  - 목록·상세·생성·삭제·검색·통계 등 응답 형식을 일관되게 표시해 클라이언트 연동 예측 가능성 증대.
  - 사용자 위치 조회 API에도 응답 스키마 및 오류 명시를 추가해 스펙을 명확화.
  - 런타임 동작 변화 없음; 문서 품질과 개발자 경험 개선.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->