### PR TITLE
feat: 사용자 프로필 변경 수정 및 publicId 조회 API 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/chat/repository/ChatMessageRepository.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/ChatMessageRepository.java
@@ -15,4 +15,6 @@ public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long>,
     Optional<ChatMessage> findFirstByChatRoom_IdOrderByCreatedAtDescIdDesc(Long chatRoomId);
 
     boolean existsByUser_IdAndPublicId(Long userId, String publicId);
+
+    Optional<ChatMessage> findByUser_IdAndImageUrl(Long userId, String imageUrl);
 }

--- a/src/main/java/com/uhdyl/backend/image/api/ImageApi.java
+++ b/src/main/java/com/uhdyl/backend/image/api/ImageApi.java
@@ -6,7 +6,9 @@ import com.uhdyl.backend.global.config.swagger.SwaggerApiResponses;
 import com.uhdyl.backend.global.config.swagger.SwaggerApiSuccessResponse;
 import com.uhdyl.backend.global.exception.ExceptionType;
 import com.uhdyl.backend.global.response.ResponseBody;
+import com.uhdyl.backend.image.domain.ImageType;
 import com.uhdyl.backend.image.dto.request.*;
+import com.uhdyl.backend.image.dto.response.ImagePublicIdResponse;
 import com.uhdyl.backend.image.dto.response.ImageSavedSuccessResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -17,10 +19,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
@@ -174,5 +173,32 @@ public interface ImageApi {
     public ResponseEntity<ResponseBody<Void>> deleteImage(
             @RequestBody List<ImageDeleteRequest> request,
             @Parameter(hidden = true) Long userId
+    );
+
+    @Operation(
+            summary = "publicId 조회",
+            description = "이미지 삭제를 위한 publicId를 조회합니다."
+    )
+    @ApiResponse(content = @Content(schema = @Schema(implementation = ImagePublicIdResponse.class)))
+    @SwaggerApiResponses(
+            success = @SwaggerApiSuccessResponse(
+                    response = ImagePublicIdResponse.class,
+                    description = "이미지 삭제 성공"
+            ),
+            errors = {
+                    @SwaggerApiFailedResponse(ExceptionType.NEED_AUTHORIZED),
+                    @SwaggerApiFailedResponse(ExceptionType.IMAGE_ACCESS_DENIED),
+                    @SwaggerApiFailedResponse(ExceptionType.USER_NOT_FOUND),
+                    @SwaggerApiFailedResponse(ExceptionType.IMAGE_ACCESS_DENIED),
+                    @SwaggerApiFailedResponse(ExceptionType.REVIEW_NOT_FOUND)
+            }
+    )
+    @GetMapping("/image/publicId")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<ImagePublicIdResponse>> getPublicId(
+            Long userId,
+            @RequestParam String imageUrl,
+            @RequestParam ImageType imageType
     );
 }

--- a/src/main/java/com/uhdyl/backend/image/controller/ImageController.java
+++ b/src/main/java/com/uhdyl/backend/image/controller/ImageController.java
@@ -3,7 +3,9 @@ package com.uhdyl.backend.image.controller;
 import com.uhdyl.backend.global.aop.AssignUserId;
 import com.uhdyl.backend.global.response.ResponseBody;
 import com.uhdyl.backend.image.api.ImageApi;
+import com.uhdyl.backend.image.domain.ImageType;
 import com.uhdyl.backend.image.dto.request.ImageDeleteRequest;
+import com.uhdyl.backend.image.dto.response.ImagePublicIdResponse;
 import com.uhdyl.backend.image.dto.response.ImageSavedSuccessResponse;
 import com.uhdyl.backend.image.service.ImageService;
 import lombok.RequiredArgsConstructor;
@@ -94,6 +96,17 @@ public class ImageController implements ImageApi {
     ){
         imageService.deleteImage(request, userId);
         return ResponseEntity.ok(createSuccessResponse());
+    }
+
+    @GetMapping("/image/publicId")
+    @AssignUserId
+    @PreAuthorize("isAuthenticated() and hasRole('USER')")
+    public ResponseEntity<ResponseBody<ImagePublicIdResponse>> getPublicId(
+            Long userId,
+            @RequestParam String imageUrl,
+            @RequestParam ImageType imageType
+    ){
+        return ResponseEntity.ok(createSuccessResponse(imageService.getPublicId(userId, imageUrl, imageType)));
     }
 
 }

--- a/src/main/java/com/uhdyl/backend/image/dto/response/ImagePublicIdResponse.java
+++ b/src/main/java/com/uhdyl/backend/image/dto/response/ImagePublicIdResponse.java
@@ -1,0 +1,9 @@
+package com.uhdyl.backend.image.dto.response;
+
+public record ImagePublicIdResponse(
+        String publicId
+) {
+    public static ImagePublicIdResponse to(String publicId){
+        return new ImagePublicIdResponse(publicId);
+    }
+}

--- a/src/main/java/com/uhdyl/backend/image/repository/ImageRepository.java
+++ b/src/main/java/com/uhdyl/backend/image/repository/ImageRepository.java
@@ -3,6 +3,11 @@ package com.uhdyl.backend.image.repository;
 import com.uhdyl.backend.image.domain.Image;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface ImageRepository extends JpaRepository<Image, Long>, CustomImageRepository {
     void deleteByPublicId(String publicId);
+
+    Optional<Image> findByImageUrl(String imageUrl);
 }

--- a/src/main/java/com/uhdyl/backend/image/service/ImageService.java
+++ b/src/main/java/com/uhdyl/backend/image/service/ImageService.java
@@ -6,10 +6,14 @@ import com.uhdyl.backend.chat.domain.ChatMessage;
 import com.uhdyl.backend.chat.repository.ChatMessageRepository;
 import com.uhdyl.backend.global.exception.BusinessException;
 import com.uhdyl.backend.global.exception.ExceptionType;
+import com.uhdyl.backend.image.domain.Image;
 import com.uhdyl.backend.image.domain.ImageType;
 import com.uhdyl.backend.image.dto.request.ImageDeleteRequest;
+import com.uhdyl.backend.image.dto.response.ImagePublicIdResponse;
 import com.uhdyl.backend.image.dto.response.ImageSavedSuccessResponse;
 import com.uhdyl.backend.image.repository.ImageRepository;
+import com.uhdyl.backend.product.domain.Product;
+import com.uhdyl.backend.product.repository.ProductRepository;
 import com.uhdyl.backend.review.domain.Review;
 import com.uhdyl.backend.review.repository.ReviewRepository;
 import com.uhdyl.backend.user.domain.User;
@@ -26,6 +30,7 @@ import java.util.UUID;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class ImageService {
 
     private final Cloudinary cloudinary;
@@ -33,6 +38,7 @@ public class ImageService {
     private final UserRepository userRepository;
     private final ChatMessageRepository chatMessageRepository;
     private final ReviewRepository reviewRepository;
+    private final ProductRepository productRepository;
 
     public ImageSavedSuccessResponse uploadImage(MultipartFile image, String folderPath){
 
@@ -63,7 +69,6 @@ public class ImageService {
     @Transactional
     public void deleteImage(List<ImageDeleteRequest> request, Long userId){
 
-        // TODO: 리뷰 도메인 추가 시 로직 추가하기
         request.forEach(imageDeleteRequest -> {
             ImageType imageType = imageDeleteRequest.imageType();
             String publicId = imageDeleteRequest.publicId();
@@ -111,4 +116,35 @@ public class ImageService {
 
     }
 
+    public ImagePublicIdResponse getPublicId(Long userId, String imageUrl, ImageType imageType){
+        if(!userRepository.existsById(userId))
+            throw new BusinessException(ExceptionType.USER_NOT_FOUND);
+
+        switch (imageType){
+            case USER_IMAGE -> {
+                User user = userRepository.findById(userId)
+                        .orElseThrow(() -> new BusinessException(ExceptionType.USER_NOT_FOUND));
+                return ImagePublicIdResponse.to(user.getPublicId());
+            }
+
+            case PRODUCT_IMAGE -> {
+                Image image = imageRepository.findByImageUrl(imageUrl)
+                        .orElseThrow(() -> new BusinessException(ExceptionType.IMAGE_ACCESS_DENIED));
+                return ImagePublicIdResponse.to(image.getPublicId());
+            }
+
+            case CHAT_IMAGE -> {
+                ChatMessage chatMessage = chatMessageRepository.findByUser_IdAndImageUrl(userId, imageUrl)
+                        .orElseThrow(() -> new BusinessException(ExceptionType.IMAGE_ACCESS_DENIED));
+                return ImagePublicIdResponse.to(chatMessage.getPublicId());
+            }
+
+            case REVIEW_IMAGE -> {
+                Review review = reviewRepository.findByUser_IdAndImageUrl(userId, imageUrl)
+                        .orElseThrow(() -> new BusinessException(ExceptionType.REVIEW_NOT_FOUND));
+                return ImagePublicIdResponse.to(review.getPublicId());
+            }
+        }
+        return ImagePublicIdResponse.to("이미지가 존재하지 않습니다.");
+    }
 }

--- a/src/main/java/com/uhdyl/backend/product/repository/ProductRepository.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/ProductRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ProductRepository extends JpaRepository<Product, Long>, CustomProductRepository {
     Optional<Product> findByIdAndUser_Id(Long productId, Long userId);
+
+    Optional<Product> findByUser_Id(Long userId);
 }

--- a/src/main/java/com/uhdyl/backend/review/repository/ReviewRepository.java
+++ b/src/main/java/com/uhdyl/backend/review/repository/ReviewRepository.java
@@ -3,7 +3,11 @@ package com.uhdyl.backend.review.repository;
 import com.uhdyl.backend.review.domain.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface ReviewRepository extends JpaRepository<Review, Long>, CustomReviewRepository {
     Review findByPublicId(String publicId);
     boolean existsByUser_IdAndPublicId(Long userId, String publicId);
+
+    Optional<Review> findByUser_IdAndImageUrl(Long userId, String imageUrl);
 }

--- a/src/main/java/com/uhdyl/backend/user/domain/User.java
+++ b/src/main/java/com/uhdyl/backend/user/domain/User.java
@@ -111,7 +111,7 @@ public class User extends BaseEntity {
         this.nickname = nickname;
     }
 
-    public void updateProfile(JsonNullable<String> picture, JsonNullable<String> nickname, JsonNullable<String> mode){
+    public void updateProfile(JsonNullable<String> picture, JsonNullable<String> nickname, JsonNullable<String> mode, JsonNullable<String> publicId){
 
         if(picture.isPresent())
             this.picture = picture.get();
@@ -119,6 +119,9 @@ public class User extends BaseEntity {
             this.nickname = nickname.get();
         if(mode.isPresent())
             this.mode = mode.get();
+        if(publicId.isPresent())
+            this.publicId = publicId.get();
+
     }
 
     public void updateUserToFarmer(){

--- a/src/main/java/com/uhdyl/backend/user/dto/request/UserProfileUpdateRequest.java
+++ b/src/main/java/com/uhdyl/backend/user/dto/request/UserProfileUpdateRequest.java
@@ -7,6 +7,9 @@ public record UserProfileUpdateRequest (
         @Schema(description = "프로필 이미지 url", example = "http://어쩌구저쩌구")
         JsonNullable<String> profileImageUrl,
 
+        @Schema(description = "프로필 이미지 publicId", example = "dummy")
+        JsonNullable<String> publicId,
+
         @Schema(description = "유저 닉네임", example = "치킨먹는고양이")
         JsonNullable<String> nickname,
 

--- a/src/main/java/com/uhdyl/backend/user/service/UserService.java
+++ b/src/main/java/com/uhdyl/backend/user/service/UserService.java
@@ -86,7 +86,7 @@ public class UserService {
         if(request.nickname().isPresent() && userRepository.existsByNickname(request.nickname().get()))
             throw new BusinessException(ExceptionType.USER_NICKNAME_DUPLICATED);
 
-        user.updateProfile(request.profileImageUrl(), request.nickname(), request.mode());
+        user.updateProfile(request.profileImageUrl(), request.nickname(), request.mode(), request.publicId());
     }
 
     @Transactional


### PR DESCRIPTION
## What is this PR?🔍
- 사용자 프로필 변경 시 이미지 삭제를 위한 publicId도 함께 입력받도록 수정합니다.
- 이미지 삭제를 위한 publicId를 조회하는 API를 추가합니다.
- 
## Changes💻
- publicId 조회 APi가 추가되어 이미지 삭제 과정이 변경되었습니다.
- 이전에는 이미지 삭제 API를 호출하면 이미지 삭제가 완료되었지만
- 현재 PR 이후부터 publicId 조회 API를 호출 후 발급받은 publicId를 통해 이미지 삭제 API를 호출하여 이미지 삭제를 진행합니다.
-

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신규 기능
  * 이미지 URL과 유형을 기반으로 publicId를 조회하는 인증 필요 API가 추가되었습니다.
  * 사용자 프로필 수정 시 프로필 이미지의 publicId를 함께 업데이트할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->