### PR TITLE
chore: 채팅 메시지 반환 시 이름 대신 닉네임 전달

### DIFF
--- a/src/main/java/com/uhdyl/backend/chat/dto/response/ChatMessageResponse.java
+++ b/src/main/java/com/uhdyl/backend/chat/dto/response/ChatMessageResponse.java
@@ -13,7 +13,7 @@ public record ChatMessageResponse (
         LocalDateTime timestamp
 ){
     public static ChatMessageResponse to(ChatMessage message) {
-        return new ChatMessageResponse(message.getMessage(), message.getUser().getId(), message.getUser().getName(), message.getImageUrl(), message.getCreatedAt());
+        return new ChatMessageResponse(message.getMessage(), message.getUser().getId(), message.getUser().getNickname(), message.getImageUrl(), message.getCreatedAt());
     }
 
     public static List<ChatMessageResponse> to(List<ChatMessage> message) {


### PR DESCRIPTION
## What is this PR?🔍
- 채팅 메시지 반환 시 이름 대신 닉네임을 전달하도록 변경합니다.
## Changes💻

-
-
-

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 채팅 메시지에서 발신자가 사용자 “이름”으로 표시되던 문제를 수정하여, 이제 프로필 “닉네임”이 표시됩니다. 대화 목록과 채팅방 화면 모두에서 일관되게 닉네임이 노출되며, 기존 및 신규 메시지에 동일하게 적용됩니다. 그 외 동작과 화면 구성에는 변화가 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->