### PR TITLE
feat: 채팅방 목록 반환 시 거래 완료 여부도 함께 전달

### DIFF
--- a/src/main/java/com/uhdyl/backend/chat/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/uhdyl/backend/chat/dto/response/ChatRoomResponse.java
@@ -13,7 +13,8 @@ public record ChatRoomResponse(
         String chatRoomName,
         ProductListResponse product,
         String message,
-        LocalDateTime timestamp
+        LocalDateTime timestamp,
+        boolean isTradeCompleted
 ) {
     public static ChatRoomResponse to(ChatRoom chatRoom, Product product, ChatMessage chatMessage) {
         return new ChatRoomResponse(
@@ -21,7 +22,8 @@ public record ChatRoomResponse(
                 chatRoom.getChatRoomTitle(),
                 ProductListResponse.to(product),
                 chatMessage == null ? "" : chatMessage.getMessage(),
-                chatMessage == null ? chatRoom.getCreatedAt() : chatMessage.getCreatedAt()
+                chatMessage == null ? chatRoom.getCreatedAt() : chatMessage.getCreatedAt(),
+                chatRoom.isTradeCompleted()
         );
     }
 

--- a/src/main/java/com/uhdyl/backend/chat/repository/CustomChatRoomRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/CustomChatRoomRepositoryImpl.java
@@ -62,7 +62,8 @@ public class CustomChatRoomRepositoryImpl implements CustomChatRoomRepository{
                                 qProduct.isSale
                         ),
                         qChatMessage.message,
-                        qChatMessage.createdAt
+                        qChatMessage.createdAt,
+                        qChatRoom.tradeCompleted
                 ))
                 .from(qChatRoom)
                 .leftJoin(qProduct).on(qProduct.id.eq(qChatRoom.productId))


### PR DESCRIPTION
## What is this PR?🔍
- 채팅방 목록 반환 시 해당 채팅방의 거래가 완료되었는지 알려주는 필드 isTradeCompleted를 함께 전달합니다.
## Changes💻

-
-
-

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 채팅방 정보에 거래 완료 여부가 추가되어, 목록/상세 화면에서 거래 상태를 확인할 수 있습니다.
  * API 응답에 거래 완료 플래그가 포함되어 클라이언트에서 배지/아이콘 등 상태 표시가 가능해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->