### PR TITLE
fix: 이미지 URL 검증 로직 제거

### DIFF
--- a/src/main/java/com/uhdyl/backend/product/service/AiContentService.java
+++ b/src/main/java/com/uhdyl/backend/product/service/AiContentService.java
@@ -155,19 +155,18 @@ public class AiContentService {
      * @throws IOException 이미지 다운로드/변환 실패 시
      */
     public String createDataUriFromUrl(String imageUrl) throws IOException {
-        validateExternalImageUrl(imageUrl);
 
         byte[] imageBytes = restTemplate.getForObject(imageUrl, byte[].class);
         if (imageBytes == null || imageBytes.length == 0) {
             throw new IOException("이미지 다운로드 실패: 빈 응답");
         }
-        final int maxBytes = 5 * 1024 * 1024; // 5MB
+        final int maxBytes = 5 * 1024 * 1024;
         if (imageBytes.length > maxBytes) {
             throw new IOException("이미지 용량 초과(5MB Max): " + imageBytes.length);
         }
 
         String base64Image = Base64.getEncoder().encodeToString(imageBytes);
-        String mimeType = detectMimeType(imageUrl); // 간단한 MIME 타입 추론
+        String mimeType = detectMimeType(imageUrl);
 
         return "data:" + mimeType + ";base64," + base64Image;
     }
@@ -182,21 +181,6 @@ public class AiContentService {
             return "image/webp";
         }
         return "image/jpeg";
-    }
-
-    private void validateExternalImageUrl(String imageUrl) {
-        try {
-            URI uri = new URI(imageUrl);
-            String host = uri.getHost();
-            if (host == null) throw new IllegalArgumentException("호스트가 없는 URL");
-
-            java.net.InetAddress addr = java.net.InetAddress.getByName(host);
-            if (addr.isAnyLocalAddress() || addr.isLoopbackAddress() || addr.isSiteLocalAddress()) {
-                throw new IllegalArgumentException("허용되지 않은 내부/사설 네트워크 접근");
-            }
-        } catch (URISyntaxException | java.net.UnknownHostException e) {
-            throw new IllegalArgumentException("유효하지 않은 이미지 URL", e);
-        }
     }
 
     private static String extractJsonOnly(String s) {


### PR DESCRIPTION
## What is this PR?🔍

- validateExternalImageUrl 메서드 및 호출 부분을 삭제하였습니다.
- 도메인이 사설망 IP로 해석돼서 isSiteLocalAddress() 에 걸림 이슈로 글 작성이 막힘

## Changes💻

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 외부 이미지로부터 데이터 URI 생성 시 지원 범위를 확대하여 더 다양한 이미지 URL을 사용할 수 있습니다.
* 버그 수정
  * 일부 정상적인 외부 이미지 URL에서 발생하던 불필요한 차단/실패 가능성을 낮춰 성공률을 개선했습니다.
* 기타
  * 내부 주석 및 포맷 정리를 통해 코드 가독성을 소폭 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->