### PR TITLE
feat: 상품 목록 조회 DTO 필드 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/chat/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/uhdyl/backend/chat/dto/response/ChatRoomResponse.java
@@ -3,6 +3,7 @@ package com.uhdyl.backend.chat.dto.response;
 import com.uhdyl.backend.chat.domain.ChatMessage;
 import com.uhdyl.backend.chat.domain.ChatRoom;
 import com.uhdyl.backend.product.domain.Product;
+import com.uhdyl.backend.product.dto.response.ChatRoomProductResponse;
 import com.uhdyl.backend.product.dto.response.ProductListResponse;
 
 import java.time.LocalDateTime;
@@ -11,7 +12,7 @@ import java.time.LocalDateTime;
 public record ChatRoomResponse(
         Long chatRoomId,
         String chatRoomName,
-        ProductListResponse product,
+        ChatRoomProductResponse product,
         String message,
         LocalDateTime timestamp,
         boolean isTradeCompleted
@@ -20,7 +21,7 @@ public record ChatRoomResponse(
         return new ChatRoomResponse(
                 chatRoom.getId(),
                 chatRoom.getChatRoomTitle(),
-                ProductListResponse.to(product),
+                ChatRoomProductResponse.to(product),
                 chatMessage == null ? "" : chatMessage.getMessage(),
                 chatMessage == null ? chatRoom.getCreatedAt() : chatMessage.getCreatedAt(),
                 chatRoom.isTradeCompleted()

--- a/src/main/java/com/uhdyl/backend/chat/repository/CustomChatRoomRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/chat/repository/CustomChatRoomRepositoryImpl.java
@@ -12,6 +12,7 @@ import com.uhdyl.backend.chat.dto.response.ChatRoomResponse;
 import com.uhdyl.backend.global.response.GlobalPageResponse;
 import com.uhdyl.backend.image.domain.QImage;
 import com.uhdyl.backend.product.domain.QProduct;
+import com.uhdyl.backend.product.dto.response.ChatRoomProductResponse;
 import com.uhdyl.backend.product.dto.response.ProductListResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
@@ -52,7 +53,7 @@ public class CustomChatRoomRepositoryImpl implements CustomChatRoomRepository{
                         qChatRoom.id,
                         qChatRoom.chatRoomTitle,
                         Projections.constructor(
-                                ProductListResponse.class,
+                                ChatRoomProductResponse.class,
                                 qProduct.id,
                                 qProduct.title,
                                 qProduct.price,

--- a/src/main/java/com/uhdyl/backend/product/dto/response/ChatRoomProductResponse.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/response/ChatRoomProductResponse.java
@@ -1,0 +1,37 @@
+package com.uhdyl.backend.product.dto.response;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.uhdyl.backend.product.domain.Product;
+
+public record ChatRoomProductResponse(
+        Long id,
+        String title,
+        Long price,
+        String sellerName,
+        String sellerPicture,
+        String mainImageUrl,
+        boolean isCompleted
+) {
+    @QueryProjection
+    public ChatRoomProductResponse(Long id, String title, Long price, String sellerName, String sellerPicture, String mainImageUrl, boolean isCompleted) {
+        this.id = id;
+        this.title = title;
+        this.price = price;
+        this.sellerName = sellerName;
+        this.sellerPicture = sellerPicture;
+        this.mainImageUrl = mainImageUrl;
+        this.isCompleted = isCompleted;
+    }
+
+    public static ChatRoomProductResponse to(Product product){
+        return new ChatRoomProductResponse(
+                product.getId(),
+                product.getTitle(),
+                product.getPrice(),
+                product.getUser().getNickname(),
+                product.getUser().getPicture(),
+                product.getImages().get(0).getImageUrl(),
+                product.isSale()
+        );
+    }
+}

--- a/src/main/java/com/uhdyl/backend/product/dto/response/ProductListResponse.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/response/ProductListResponse.java
@@ -10,10 +10,11 @@ public record ProductListResponse(
         String sellerName,
         String sellerPicture,
         String mainImageUrl,
-        boolean isCompleted
+        boolean isCompleted,
+        Long zzimCount
 ) {
     @QueryProjection
-    public ProductListResponse(Long id, String title, Long price, String sellerName, String sellerPicture, String mainImageUrl, boolean isCompleted) {
+    public ProductListResponse(Long id, String title, Long price, String sellerName, String sellerPicture, String mainImageUrl, boolean isCompleted, Long zzimCount) {
         this.id = id;
         this.title = title;
         this.price = price;
@@ -21,17 +22,6 @@ public record ProductListResponse(
         this.sellerPicture = sellerPicture;
         this.mainImageUrl = mainImageUrl;
         this.isCompleted = isCompleted;
-    }
-
-    public static ProductListResponse to(Product product){
-        return new ProductListResponse(
-                product.getId(),
-                product.getTitle(),
-                product.getPrice(),
-                product.getUser().getNickname(),
-                product.getUser().getPicture(),
-                product.getImages().get(0).getImageUrl(),
-                product.isSale()
-        );
+        this.zzimCount = zzimCount;
     }
 }

--- a/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
@@ -200,6 +200,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
         QProduct product = QProduct.product;
         QImage image = QImage.image;
         QUser user = QUser.user;
+        QZzim zzim = QZzim.zzim;
 
         PathBuilder<Product> entityPath = new PathBuilder<>(Product.class, "product");
 
@@ -213,13 +214,17 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                         user.nickname.coalesce(user.name).coalesce(""),
                         user.picture.coalesce(""),
                         image.imageUrl,
-                        product.isSale.not()
+                        product.isSale.not(),
+                        zzim.id.count()
+
                 ))
                 .from(product)
                 .leftJoin(product.images, image).on(image.imageOrder.eq(0L))
                 .leftJoin(product.user, user)
+                .leftJoin(zzim).on(zzim.product.id.eq(product.id))
                 .where(product.isSale.eq(true))
                 .orderBy(orderSpecifiers)
+                .groupBy(product.id, product.title, product.price, user.nickname, user.name, user.picture, image.imageUrl, product.isSale, zzim.id)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
@@ -57,6 +57,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
         QProduct product = QProduct.product;
         QImage image = QImage.image;
         QUser user = QUser.user;
+        QZzim zzim = QZzim.zzim;
 
         PathBuilder<Product> entityPath = new PathBuilder<>(Product.class, "product");
 
@@ -70,12 +71,15 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                         user.nickname.coalesce(user.name).coalesce(""),
                         user.picture,
                         image.imageUrl.min(),
-                        product.isSale.not()
+                        product.isSale.not(),
+                        zzim.id.count()
                 ))
                 .from(product)
+                .leftJoin(product.user, user)
                 .leftJoin(product.images, image).on(image.imageOrder.eq(0L))
+                .leftJoin(zzim).on(zzim.product.id.eq(product.id))
                 .where(product.user.id.eq(userId))
-                .groupBy(product.id, product.title, product.price, user.nickname, user.name, user.picture, product.isSale)
+                .groupBy(product.id, product.title, product.price, user.nickname, user.name, user.picture, image.imageUrl, product.isSale)
                 .orderBy(orderSpecifiers)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
@@ -224,7 +228,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                 .leftJoin(zzim).on(zzim.product.id.eq(product.id))
                 .where(product.isSale.eq(true))
                 .orderBy(orderSpecifiers)
-                .groupBy(product.id, product.title, product.price, user.nickname, user.name, user.picture, image.imageUrl, product.isSale, zzim.id)
+                .groupBy(product.id, product.title, product.price, user.nickname, user.name, user.picture, image.imageUrl, product.isSale)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -279,7 +283,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                 .leftJoin(zzim).on(zzim.product.id.eq(product.id))
                 .where(whereClause)
                 .orderBy(orderSpecifiers)
-                .groupBy(product.id, product.title, product.price, user.nickname, user.name, user.picture, image.imageUrl, product.isSale, zzim.id)
+                .groupBy(product.id, product.title, product.price, user.nickname, user.name, user.picture, image.imageUrl, product.isSale)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();

--- a/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
@@ -245,6 +245,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
         QProduct product = QProduct.product;
         QImage image = QImage.image;
         QUser user = QUser.user;
+        QZzim zzim = QZzim.zzim;
 
         BooleanBuilder whereClause = new BooleanBuilder();
         whereClause.and(product.isSale.eq(true));
@@ -269,13 +270,16 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                         user.nickname.coalesce(user.name).coalesce(""),
                         user.picture.coalesce(""),
                         image.imageUrl,
-                        product.isSale.not()
+                        product.isSale.not(),
+                        zzim.id.count()
                 ))
                 .from(product)
                 .leftJoin(product.user, user)
                 .leftJoin(product.images, image).on(image.imageOrder.eq(0L))
+                .leftJoin(zzim).on(zzim.product.id.eq(product.id))
                 .where(whereClause)
                 .orderBy(orderSpecifiers)
+                .groupBy(product.id, product.title, product.price, user.nickname, user.name, user.picture, image.imageUrl, product.isSale, zzim.id)
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();


### PR DESCRIPTION
## What is this PR?🔍
- 상품 목록 조회 시 각 상품의 찜 횟수를 함께 반환하도록 필드를 추가합니다.
- 상품 상세 조회는 변경하지 않았습니다. 
- 
## Changes💻

-
-
-

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 채팅방에 표시되는 상품 정보가 확장되어 제목, 가격, 판매자 닉네임/프로필, 대표 이미지, 거래 완료 여부가 보다 명확하게 제공됩니다.
  - 상품 목록·검색 결과에 상품별 찜(좋아요) 수가 표시됩니다.
  - 상품 상세에서 현재 사용자가 해당 상품을 찜했는지 여부가 표시됩니다.

- Refactor
  - 채팅방용 상품 응답 구조를 재정비하여 화면 간 일관성과 데이터 명확성을 높였습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->