### PR TITLE
refactor: 이미지 롤백 메서드 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/image/controller/ImageController.java
+++ b/src/main/java/com/uhdyl/backend/image/controller/ImageController.java
@@ -35,8 +35,9 @@ public class ImageController implements ImageApi {
             Long userId,
             @RequestParam MultipartFile image
     ){
+        MultipartFile[] images = {image};
         return ResponseEntity.ok(createSuccessResponse(
-                imageService.uploadImage(image, "profile/" + userId + "/")
+                imageService.uploadImage(images, "profile/" + userId + "/").get(0)
         ));
     }
 
@@ -49,8 +50,9 @@ public class ImageController implements ImageApi {
             @RequestParam Long roomId,
             @RequestParam MultipartFile image
     ){
+        MultipartFile[] images = {image};
         return ResponseEntity.ok(createSuccessResponse(
-                imageService.uploadImage(image, "chat/" + roomId + "/")
+                imageService.uploadImage(images, "chat/" + roomId + "/").get(0)
         ));
     }
 
@@ -62,15 +64,9 @@ public class ImageController implements ImageApi {
     public ResponseEntity<ResponseBody<List<ImageSavedSuccessResponse>>> uploadProductImage(
             @RequestParam List<MultipartFile> images
     ){
-
-        List<ImageSavedSuccessResponse> response = new ArrayList<>();
-        for(int i = 0; i < images.size(); i++){
-            response.add(
-                    imageService.uploadImage(images.get(i), "product/" + (i + 1) + "/")
-            );
-        }
-
-        return ResponseEntity.ok(createSuccessResponse(response));
+        MultipartFile[] imageArray = new MultipartFile[images.size()];
+        images.toArray(imageArray);
+        return ResponseEntity.ok(createSuccessResponse(imageService.uploadImage(imageArray, "product/" + 1 + "/")));
     }
 
     @PostMapping("/image/review")
@@ -80,8 +76,9 @@ public class ImageController implements ImageApi {
             Long userId,
             @RequestParam MultipartFile image
     ){
+        MultipartFile[] images = {image};
         return ResponseEntity.ok(createSuccessResponse(
-                imageService.uploadImage(image, "review/" + userId + "/")
+                imageService.uploadImage(images, "review/" + userId + "/").get(0)
         ));
     }
     /**

--- a/src/main/java/com/uhdyl/backend/image/service/ImageService.java
+++ b/src/main/java/com/uhdyl/backend/image/service/ImageService.java
@@ -24,10 +24,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 
 @Service
 @Slf4j
@@ -42,6 +39,9 @@ public class ImageService {
     private final ReviewRepository reviewRepository;
     private final ProductRepository productRepository;
 
+    private static final Set<String> ALLOWED_CONTENT_TYPES =
+            Set.of("image/jpeg", "image/png", "image/webp", "image/gif");
+
     public List<ImageSavedSuccessResponse> uploadImage(MultipartFile[] images, String folderPath){
 
         List<String> uploadedImagesPublicId = new ArrayList<>();
@@ -55,6 +55,10 @@ public class ImageService {
 
                 if (image.getSize() > 1024 * 1024 * 5)
                     throw new BusinessException(ExceptionType.IMAGE_SIZE_EXCEEDED);
+
+                String contentType = image.getContentType();
+                if (!ALLOWED_CONTENT_TYPES.contains(contentType))
+                    throw new BusinessException(ExceptionType.INVALID_IMAGE_FILE);
 
                 Map<?, ?> result = cloudinary.uploader().upload(
                         image.getBytes(),

--- a/src/main/java/com/uhdyl/backend/image/service/ImageService.java
+++ b/src/main/java/com/uhdyl/backend/image/service/ImageService.java
@@ -12,23 +12,25 @@ import com.uhdyl.backend.image.dto.request.ImageDeleteRequest;
 import com.uhdyl.backend.image.dto.response.ImagePublicIdResponse;
 import com.uhdyl.backend.image.dto.response.ImageSavedSuccessResponse;
 import com.uhdyl.backend.image.repository.ImageRepository;
-import com.uhdyl.backend.product.domain.Product;
 import com.uhdyl.backend.product.repository.ProductRepository;
 import com.uhdyl.backend.review.domain.Review;
 import com.uhdyl.backend.review.repository.ReviewRepository;
 import com.uhdyl.backend.user.domain.User;
 import com.uhdyl.backend.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class ImageService {
@@ -40,30 +42,45 @@ public class ImageService {
     private final ReviewRepository reviewRepository;
     private final ProductRepository productRepository;
 
-    public ImageSavedSuccessResponse uploadImage(MultipartFile image, String folderPath){
+    public List<ImageSavedSuccessResponse> uploadImage(MultipartFile[] images, String folderPath){
 
-        if(image == null || image.isEmpty())
-            throw new BusinessException(ExceptionType.INVALID_IMAGE_FILE);
-
-        if(image.getSize() > 1024 * 1024 * 5)
-            throw new BusinessException(ExceptionType.IMAGE_SIZE_EXCEEDED);
+        List<String> uploadedImagesPublicId = new ArrayList<>();
+        List<ImageSavedSuccessResponse> responses = new ArrayList<>();
 
         try {
-            Map<?, ?> result = cloudinary.uploader().upload(
-                    image.getBytes(),
-                    Map.of(
-                            "folder", folderPath,
-                            "public_id", UUID.randomUUID().toString()
-                    )
-            );
+            for (MultipartFile image : images) {
 
-            if(result.get("secure_url") == null || result.get("public_id") == null)
-                throw new BusinessException(ExceptionType.IMAGE_UPLOAD_FAILED);
+                if (image == null || image.isEmpty())
+                    throw new BusinessException(ExceptionType.INVALID_IMAGE_FILE);
 
-            return ImageSavedSuccessResponse.to(result.get("secure_url").toString(), result.get("public_id").toString());
-        } catch (IOException e) {
+                if (image.getSize() > 1024 * 1024 * 5)
+                    throw new BusinessException(ExceptionType.IMAGE_SIZE_EXCEEDED);
+
+                Map<?, ?> result = cloudinary.uploader().upload(
+                        image.getBytes(),
+                        Map.of(
+                                "folder", folderPath,
+                                "public_id", UUID.randomUUID().toString()
+                        )
+                );
+
+                uploadedImagesPublicId.add(result.get("public_id").toString());
+                if (result.get("secure_url") == null || result.get("public_id") == null)
+                    throw new BusinessException(ExceptionType.IMAGE_UPLOAD_FAILED);
+
+                responses.add(ImageSavedSuccessResponse.to(result.get("secure_url").toString(), result.get("public_id").toString()));
+
+            }
+        }
+        catch (BusinessException e) {
+            rollbackImage(uploadedImagesPublicId);
+            throw e;
+        }
+        catch (Exception e) {
+            rollbackImage(uploadedImagesPublicId);
             throw new BusinessException(ExceptionType.IMAGE_UPLOAD_FAILED);
         }
+        return responses;
     }
 
     @Transactional
@@ -146,5 +163,20 @@ public class ImageService {
             }
         }
         return ImagePublicIdResponse.to("이미지가 존재하지 않습니다.");
+    }
+
+    public void rollbackImage(List<String> publicIds){
+        try{
+            for (String publicId : publicIds) {
+                try {
+                    cloudinary.uploader().destroy(publicId, ObjectUtils.emptyMap());
+                } catch (IOException e) {
+                    log.warn("이미지 롤백에 실패했습니다. publicId : {}", publicId);
+                }
+            }
+        }
+        catch (Exception e){
+            log.warn("이미지 롤백이 일부 실패했습니다.");
+        }
     }
 }

--- a/src/main/java/com/uhdyl/backend/image/service/ImageService.java
+++ b/src/main/java/com/uhdyl/backend/image/service/ImageService.java
@@ -64,10 +64,11 @@ public class ImageService {
                         )
                 );
 
-                uploadedImagesPublicId.add(result.get("public_id").toString());
+
                 if (result.get("secure_url") == null || result.get("public_id") == null)
                     throw new BusinessException(ExceptionType.IMAGE_UPLOAD_FAILED);
 
+                uploadedImagesPublicId.add(result.get("public_id").toString());
                 responses.add(ImageSavedSuccessResponse.to(result.get("secure_url").toString(), result.get("public_id").toString()));
 
             }


### PR DESCRIPTION
## What is this PR?🔍
- 이미지 업로드 시 일관성 유지를 위해 이미지 롤백 메서드를 추가합니다.
- 
## Changes💻
- 컨트롤러에서 `ImageService`의 `uploadImage` 호출 시 기존에는 `MultipartFile`로 받은 이미지를 `uploadImage`의 인자로 넘겨주었지만, 현재는 `MultipartFile` 타입의 배열을 생성하고, 이 배열을 `uploadImage`의 인자로 넘겨줍니다. 
- 위와 같이 변경함으로써 여러 장의 이미지를 업로드 시, `uploadImage` 내에서 `cloudinary`에 저장한 이미지의 `publicId`를 저장하고 업로드 실패 시 `rollbackImage`를 호출하여 이미 업로드된 이미지를 `cloudinary`에서 삭제합니다.
- `rollbackImage`가 실행되고 이미지 삭제 실패가 발생하더라도 최대한 많은 이미지를 삭제하도록 `try catch`를 이중으로 사용했습니다.

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 제품 이미지 다중 업로드를 정식 지원하여 여러 이미지를 한 번에 업로드하고 일괄 결과를 받을 수 있습니다.

- **Bug Fixes**
  - 프로필·채팅·리뷰의 단일 이미지 업로드 동작을 유지하면서 응답 일관성을 개선했습니다.
  - 업로드 중 오류 발생 시 이미 업로드된 이미지를 자동으로 되돌려 불완전한 상태를 방지합니다.
  - 허용 파일 형식 및 최대 파일 크기(5MB) 검사 추가로 잘못된 파일에 대해 명확한 오류를 제공합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->