### PR TITLE
Feat: 상품 목록 조회 필드 추가

### DIFF
--- a/src/main/java/com/uhdyl/backend/product/dto/response/ProductListResponse.java
+++ b/src/main/java/com/uhdyl/backend/product/dto/response/ProductListResponse.java
@@ -11,10 +11,12 @@ public record ProductListResponse(
         String sellerPicture,
         String mainImageUrl,
         boolean isCompleted,
-        Long zzimCount
-) {
+        Long zzimCount,
+        Double sellerRating,
+        Long reviewsCount
+        ) {
     @QueryProjection
-    public ProductListResponse(Long id, String title, Long price, String sellerName, String sellerPicture, String mainImageUrl, boolean isCompleted, Long zzimCount) {
+    public ProductListResponse(Long id, String title, Long price, String sellerName, String sellerPicture, String mainImageUrl, boolean isCompleted, Long zzimCount, Double sellerRating, Long reviewsCount) {
         this.id = id;
         this.title = title;
         this.price = price;
@@ -23,5 +25,7 @@ public record ProductListResponse(
         this.mainImageUrl = mainImageUrl;
         this.isCompleted = isCompleted;
         this.zzimCount = zzimCount;
+        this.sellerRating = sellerRating;
+        this.reviewsCount = reviewsCount;
     }
 }

--- a/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
+++ b/src/main/java/com/uhdyl/backend/product/repository/CustomProductRepositoryImpl.java
@@ -205,6 +205,7 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
         QImage image = QImage.image;
         QUser user = QUser.user;
         QZzim zzim = QZzim.zzim;
+        QReview review = QReview.review;
 
         PathBuilder<Product> entityPath = new PathBuilder<>(Product.class, "product");
 
@@ -219,8 +220,15 @@ public class CustomProductRepositoryImpl implements CustomProductRepository{
                         user.picture.coalesce(""),
                         image.imageUrl,
                         product.isSale.not(),
-                        zzim.id.count()
-
+                        zzim.id.count(),
+                        JPAExpressions
+                                .select(review.rating.avg().coalesce(0.0))
+                                .from(review)
+                                .where(review.targetUserId.eq(user.id).and(review.productId.eq(product.id))),
+                        JPAExpressions
+                                .select(review.count())
+                                .from(review)
+                                .where(review.targetUserId.eq(product.user.id).and(review.productId.eq(product.id)))
                 ))
                 .from(product)
                 .leftJoin(product.images, image).on(image.imageOrder.eq(0L))

--- a/src/main/java/com/uhdyl/backend/review/domain/Review.java
+++ b/src/main/java/com/uhdyl/backend/review/domain/Review.java
@@ -22,7 +22,7 @@ public class Review extends BaseEntity {
 
     private String publicId;
 
-    private Long rating;
+    private Double rating;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id")
@@ -33,7 +33,7 @@ public class Review extends BaseEntity {
     private Long productId;
 
     @Builder
-    public Review(User user, String content, String imageUrl, String publicId, Long rating, Long targetUserId, Long productId) {
+    public Review(User user, String content, String imageUrl, String publicId, Double rating, Long targetUserId, Long productId) {
         this.user = user;
         this.content = content;
         this.imageUrl = imageUrl;

--- a/src/main/java/com/uhdyl/backend/review/dto/request/ReviewCreateRequest.java
+++ b/src/main/java/com/uhdyl/backend/review/dto/request/ReviewCreateRequest.java
@@ -2,7 +2,7 @@ package com.uhdyl.backend.review.dto.request;
 
 public record ReviewCreateRequest (
         String content,
-        Long rating,
+        Double rating,
         String imageUrl,
         String publicId,
         Long productId

--- a/src/main/java/com/uhdyl/backend/review/dto/response/ReviewResponse.java
+++ b/src/main/java/com/uhdyl/backend/review/dto/response/ReviewResponse.java
@@ -4,11 +4,10 @@ import com.uhdyl.backend.review.domain.Review;
 
 import java.time.LocalDateTime;
 
-// TODO: 상품 도메인 개발 후 상품의 제목도 함께 전달하기
 public record ReviewResponse(
         Long Id,
         String content,
-        Long rating,
+        Double rating,
         String nickName,
         String imageUrl,
         String title,


### PR DESCRIPTION
## What is this PR?🔍
- 상품 목록 조회 시 리뷰 평점과 리뷰 개수를 함께 전달합니다.
- 리뷰 도메인의 평점의 자료형을 Double로 변경하여 실수를 입력받도록 합니다.
## Changes💻
- 
-
-

## ScreenShot📷


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 상품 목록에 판매자 평균 평점과 리뷰 수가 표시됩니다.
  - 판매자 신뢰도를 한눈에 확인하고, 상품별 리뷰 규모를 빠르게 파악할 수 있습니다.

- 개선
  - 리뷰 평점 표시가 정수에서 소수점 단위로 향상되어 보다 정확한 평점을 확인할 수 있습니다.
  - 상품 목록과 리뷰 관련 정보가 더 풍부해져 탐색 및 비교가 쉬워졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->